### PR TITLE
Make it easier to run rcv-err-details via runonce without collecting base metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* Add `--no-collector.hca.base-metrics` flag to disable collecting base HCA metrics
+* Add `--no-collector.switch.base-metrics` flag to disable collecting base switch metrics
+* When run with `--exporter.runonce`, the `collector` label will now have `-runonce` suffix to avoid conflicts with possible Prometheus scrape metrics
+
 ## 0.0.1 / 2021-04-27
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -49,12 +49,21 @@ If `ibnetdiscover` and `perfquery` are not in PATH then their paths need to be p
 
 If you have a large fabric where collection times are too long for Prometheus scrapes, the exporter can instead write metrics to a file that can be collected by node_exporter textfile collection.
 
-This exporter has been tested on a fabric with 109 switches each having around 36 ports and collecting only switches takes ~20 seconds.
+This exporter has been tested on a fabric with 109 switches each having around 36 ports and collecting only switches takes ~10 seconds.
 
 To collect the metrics from a file pass the `--collector.textfile.directory` flag to node_exporter like so: `--collector.textfile.directory=/var/lib/node_exporter/textfile_collector`.  Add this exporter to be executed via cron using flags like the following:
 
 * `--exporter.runonce`
 * `--exporter.output=/var/lib/node_exporter/textfile_collector/infiniband_exporter.prom`
+
+The collection time of `--collector.switch.rcv-err-details` can take much longer than base metrics due to having to execute `perfquery` once per port.
+One way to collect these metrics is collect base metrics with Prometheus scrapes and collect `--collector.switch.rcv-err-details` with runonce using the following flags (example on 8 core system, adjust `--perfquery.max-concurrent` as needed):
+
+* `--exporter.runonce`
+* `--exporter.output=/var/lib/node_exporter/textfile_collector/infiniband_exporter.prom`
+* `--no-collector.switch.base-metrics`
+* `--collector.switch.rcv-err-details`
+* `--perfquery.max-concurrent=8`
 
 ## Docker
 

--- a/collectors/ibnetdiscover.go
+++ b/collectors/ibnetdiscover.go
@@ -70,11 +70,17 @@ type IBNetDiscover struct {
 	errorMetric   float64
 	duration      float64
 	logger        log.Logger
+	collector     string
 }
 
-func NewIBNetDiscover(logger log.Logger) *IBNetDiscover {
+func NewIBNetDiscover(runonce bool, logger log.Logger) *IBNetDiscover {
+	collector := "ibnetdiscover"
+	if runonce {
+		collector = "ibnetdiscover-runonce"
+	}
 	return &IBNetDiscover{
-		logger: log.With(logger, "collector", "ibnetdiscover"),
+		logger:    log.With(logger, "collector", collector),
+		collector: collector,
 	}
 }
 
@@ -96,9 +102,9 @@ func (ib *IBNetDiscover) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (ib *IBNetDiscover) Collect(ch chan<- prometheus.Metric) {
-	ch <- prometheus.MustNewConstMetric(collectErrors, prometheus.GaugeValue, ib.errorMetric, "ibnetdiscover")
-	ch <- prometheus.MustNewConstMetric(collecTimeouts, prometheus.GaugeValue, ib.timeoutMetric, "ibnetdiscover")
-	ch <- prometheus.MustNewConstMetric(collectDuration, prometheus.GaugeValue, ib.duration, "ibnetdiscover")
+	ch <- prometheus.MustNewConstMetric(collectErrors, prometheus.GaugeValue, ib.errorMetric, ib.collector)
+	ch <- prometheus.MustNewConstMetric(collecTimeouts, prometheus.GaugeValue, ib.timeoutMetric, ib.collector)
+	ch <- prometheus.MustNewConstMetric(collectDuration, prometheus.GaugeValue, ib.duration, ib.collector)
 }
 
 func (ib *IBNetDiscover) collect() (*[]InfinibandDevice, *[]InfinibandDevice, error) {

--- a/collectors/ibnetdiscover_test.go
+++ b/collectors/ibnetdiscover_test.go
@@ -45,7 +45,7 @@ func TestIbnetdiscoverCollector(t *testing.T) {
 		# TYPE infiniband_exporter_collect_timeouts gauge
 		infiniband_exporter_collect_timeouts{collector="ibnetdiscover"} 0
 	`
-	collector := NewIBNetDiscover(log.NewNopLogger())
+	collector := NewIBNetDiscover(false, log.NewNopLogger())
 	_, _, _ = collector.GetPorts()
 	gatherers := setupGatherer(collector)
 	if val, err := testutil.GatherAndCount(gatherers); err != nil {
@@ -69,7 +69,31 @@ func TestIbnetdiscoverCollectorError(t *testing.T) {
 		# TYPE infiniband_exporter_collect_timeouts gauge
 		infiniband_exporter_collect_timeouts{collector="ibnetdiscover"} 0
 	`
-	collector := NewIBNetDiscover(log.NewNopLogger())
+	collector := NewIBNetDiscover(false, log.NewNopLogger())
+	_, _, _ = collector.GetPorts()
+	gatherers := setupGatherer(collector)
+	if val, err := testutil.GatherAndCount(gatherers); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	} else if val != 3 {
+		t.Errorf("Unexpected collection count %d, expected 3", val)
+	}
+	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
+		"infiniband_exporter_collect_errors", "infiniband_exporter_collect_timeouts"); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+}
+
+func TestIbnetdiscoverCollectorErrorRunonce(t *testing.T) {
+	SetIbnetdiscoverExec(t, true, false)
+	expected := `
+		# HELP infiniband_exporter_collect_errors Number of errors that occurred during collection
+		# TYPE infiniband_exporter_collect_errors gauge
+		infiniband_exporter_collect_errors{collector="ibnetdiscover-runonce"} 1
+		# HELP infiniband_exporter_collect_timeouts Number of timeouts that occurred during collection
+		# TYPE infiniband_exporter_collect_timeouts gauge
+		infiniband_exporter_collect_timeouts{collector="ibnetdiscover-runonce"} 0
+	`
+	collector := NewIBNetDiscover(true, log.NewNopLogger())
 	_, _, _ = collector.GetPorts()
 	gatherers := setupGatherer(collector)
 	if val, err := testutil.GatherAndCount(gatherers); err != nil {
@@ -93,7 +117,7 @@ func TestIbnetdiscoverCollectorTimeout(t *testing.T) {
 		# TYPE infiniband_exporter_collect_timeouts gauge
 		infiniband_exporter_collect_timeouts{collector="ibnetdiscover"} 1
 	`
-	collector := NewIBNetDiscover(log.NewNopLogger())
+	collector := NewIBNetDiscover(false, log.NewNopLogger())
 	_, _, _ = collector.GetPorts()
 	gatherers := setupGatherer(collector)
 	if val, err := testutil.GatherAndCount(gatherers); err != nil {

--- a/infiniband_exporter_test.go
+++ b/infiniband_exporter_test.go
@@ -264,28 +264,28 @@ infiniband_hca_uplink_info{guid="0x7cfe9003003b4b96",hca="o0002",port="1",uplink
 infiniband_hca_uplink_info{guid="0x7cfe9003003b4bde",hca="o0001",port="1",uplink="ib-i1l1s01",uplink_guid="0x7cfe9003009ce5b0",uplink_lid="1719",uplink_port="10",uplink_type="SW"} 1`
 	expectedSwitchNoError = `# HELP infiniband_exporter_collect_errors Number of errors that occurred during collection
 # TYPE infiniband_exporter_collect_errors gauge
-infiniband_exporter_collect_errors{collector="ibnetdiscover"} 0
-infiniband_exporter_collect_errors{collector="switch"} 0
+infiniband_exporter_collect_errors{collector="ibnetdiscover-runonce"} 0
+infiniband_exporter_collect_errors{collector="switch-runonce"} 0
 # HELP infiniband_exporter_collect_timeouts Number of timeouts that occurred during collection
 # TYPE infiniband_exporter_collect_timeouts gauge
-infiniband_exporter_collect_timeouts{collector="ibnetdiscover"} 0
-infiniband_exporter_collect_timeouts{collector="switch"} 0`
+infiniband_exporter_collect_timeouts{collector="ibnetdiscover-runonce"} 0
+infiniband_exporter_collect_timeouts{collector="switch-runonce"} 0`
 	expectedFullNoError = `# HELP infiniband_exporter_collect_errors Number of errors that occurred during collection
 # TYPE infiniband_exporter_collect_errors gauge
-infiniband_exporter_collect_errors{collector="hca"} 0
-infiniband_exporter_collect_errors{collector="ibnetdiscover"} 0
-infiniband_exporter_collect_errors{collector="switch"} 0
+infiniband_exporter_collect_errors{collector="hca-runonce"} 0
+infiniband_exporter_collect_errors{collector="ibnetdiscover-runonce"} 0
+infiniband_exporter_collect_errors{collector="switch-runonce"} 0
 # HELP infiniband_exporter_collect_timeouts Number of timeouts that occurred during collection
 # TYPE infiniband_exporter_collect_timeouts gauge
-infiniband_exporter_collect_timeouts{collector="hca"} 0
-infiniband_exporter_collect_timeouts{collector="ibnetdiscover"} 0
-infiniband_exporter_collect_timeouts{collector="switch"} 0`
+infiniband_exporter_collect_timeouts{collector="hca-runonce"} 0
+infiniband_exporter_collect_timeouts{collector="ibnetdiscover-runonce"} 0
+infiniband_exporter_collect_timeouts{collector="switch-runonce"} 0`
 	expectedIbnetdiscoverError = `# HELP infiniband_exporter_collect_errors Number of errors that occurred during collection
 # TYPE infiniband_exporter_collect_errors gauge
-infiniband_exporter_collect_errors{collector="ibnetdiscover"} 1
+infiniband_exporter_collect_errors{collector="ibnetdiscover-runonce"} 1
 # HELP infiniband_exporter_collect_timeouts Number of timeouts that occurred during collection
 # TYPE infiniband_exporter_collect_timeouts gauge
-infiniband_exporter_collect_timeouts{collector="ibnetdiscover"} 0`
+infiniband_exporter_collect_timeouts{collector="ibnetdiscover-runonce"} 0`
 )
 
 func TestMain(m *testing.M) {
@@ -357,6 +357,9 @@ func TestCollect(t *testing.T) {
 	if !strings.Contains(body, expectedSwitch) {
 		t.Errorf("Unexpected body\nExpected:\n%s\nGot:\n%s\n", expectedSwitch, body)
 	}
+	// remove -runonce collector suffix
+	runonceRe := regexp.MustCompile("-runonce")
+	expectedSwitchNoError = runonceRe.ReplaceAllString(expectedSwitchNoError, "")
 	if !strings.Contains(body, expectedSwitchNoError) {
 		t.Errorf("Unexpected body\nExpected:\n%s\nGot:\n%s\n", expectedSwitchNoError, body)
 	}
@@ -370,6 +373,7 @@ func TestCollect(t *testing.T) {
 	if !strings.Contains(body, expectedHCA) {
 		t.Errorf("Unexpected body\nExpected:\n%s\nGot:\n%s\n", expectedHCA, body)
 	}
+	expectedFullNoError = runonceRe.ReplaceAllString(expectedFullNoError, "")
 	if !strings.Contains(body, expectedFullNoError) {
 		t.Errorf("Unexpected body\nExpected:\n%s\nGot:\n%s\n", expectedFullNoError, body)
 	}
@@ -387,6 +391,7 @@ func TestCollect(t *testing.T) {
 	re := regexp.MustCompile(".*infiniband_exporter_collector_duration_seconds.*")
 	body = re.ReplaceAllString(body, "")
 	body = strings.TrimSpace(body)
+	expectedIbnetdiscoverError = runonceRe.ReplaceAllString(expectedIbnetdiscoverError, "")
 	if body != expectedIbnetdiscoverError {
 		t.Errorf("Unexpected body\nExpected:\n%s\nGot:\n%s\n", expectedIbnetdiscoverError, body)
 	}


### PR DESCRIPTION
* Add `--no-collector.hca.base-metrics` flag to disable collecting base HCA metrics
* Add `--no-collector.switch.base-metrics` flag to disable collecting base switch metrics
* When run with `--exporter.runonce`, the `collector` label will now have `-runonce` suffix to avoid conflicts with possible Prometheus scrape metrics