### PR TITLE
Improve how HCA port name is handled

### DIFF
--- a/collectors/collectors_test.go
+++ b/collectors/collectors_test.go
@@ -32,14 +32,14 @@ var (
 	switchDevices    = []InfinibandDevice{
 		{Type: "SW", LID: "2052", GUID: "0x506b4b03005c2740", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10, Name: "ib-i4l1s01",
 			Uplinks: map[string]InfinibandUplink{
-				"35": {Type: "CA", LID: "1432", PortNumber: "1", GUID: "0x506b4b0300cc02a6", Name: "p0001"},
+				"35": {Type: "CA", LID: "1432", PortNumber: "1", GUID: "0x506b4b0300cc02a6", Name: "p0001", PortName: "HCA-1"},
 			},
 		},
 		{Type: "SW", LID: "1719", GUID: "0x7cfe9003009ce5b0", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10, Name: "ib-i1l1s01",
 			Uplinks: map[string]InfinibandUplink{
 				"1":  {Type: "SW", LID: "1516", PortNumber: "1", GUID: "0x7cfe900300b07320", Name: "ib-i1l2s01"},
-				"10": {Type: "CA", LID: "134", PortNumber: "1", GUID: "0x7cfe9003003b4bde", Name: "o0001"},
-				"11": {Type: "CA", LID: "133", PortNumber: "1", GUID: "0x7cfe9003003b4b96", Name: "o0002"},
+				"10": {Type: "CA", LID: "134", PortNumber: "1", GUID: "0x7cfe9003003b4bde", Name: "o0001", PortName: "HCA-1"},
+				"11": {Type: "CA", LID: "133", PortNumber: "1", GUID: "0x7cfe9003003b4b96", Name: "o0002", PortName: "HCA-1"},
 			},
 		},
 	}

--- a/collectors/hca.go
+++ b/collectors/hca.go
@@ -141,9 +141,9 @@ func NewHCACollector(devices *[]InfinibandDevice, runonce bool, logger log.Logge
 		RawRate: prometheus.NewDesc(prometheus.BuildFQName(namespace, "hca", "raw_rate_bytes_per_second"),
 			"Infiniband HCA raw rate", []string{"guid"}, nil),
 		Uplink: prometheus.NewDesc(prometheus.BuildFQName(namespace, "hca", "uplink_info"),
-			"Infiniband HCA uplink information", append(labels, []string{"hca", "uplink", "uplink_guid", "uplink_type", "uplink_port", "uplink_lid"}...), nil),
+			"Infiniband HCA uplink information", append(labels, []string{"hca", "uplink", "uplink_guid", "uplink_type", "uplink_port", "uplink_port_name", "uplink_lid"}...), nil),
 		Info: prometheus.NewDesc(prometheus.BuildFQName(namespace, "hca", "info"),
-			"Infiniband HCA information", []string{"guid", "hca", "lid"}, nil),
+			"Infiniband HCA information", []string{"guid", "hca", "port_name", "lid"}, nil),
 	}
 }
 
@@ -275,9 +275,9 @@ func (h *HCACollector) Collect(ch chan<- prometheus.Metric) {
 		for _, device := range *h.devices {
 			ch <- prometheus.MustNewConstMetric(h.Rate, prometheus.GaugeValue, device.Rate, device.GUID)
 			ch <- prometheus.MustNewConstMetric(h.RawRate, prometheus.GaugeValue, device.RawRate, device.GUID)
-			ch <- prometheus.MustNewConstMetric(h.Info, prometheus.GaugeValue, 1, device.GUID, device.Name, device.LID)
+			ch <- prometheus.MustNewConstMetric(h.Info, prometheus.GaugeValue, 1, device.GUID, device.Name, device.PortName, device.LID)
 			for port, uplink := range device.Uplinks {
-				ch <- prometheus.MustNewConstMetric(h.Uplink, prometheus.GaugeValue, 1, device.GUID, port, device.Name, uplink.Name, uplink.GUID, uplink.Type, uplink.PortNumber, uplink.LID)
+				ch <- prometheus.MustNewConstMetric(h.Uplink, prometheus.GaugeValue, 1, device.GUID, port, device.Name, uplink.Name, uplink.GUID, uplink.Type, uplink.PortNumber, uplink.PortName, uplink.LID)
 			}
 		}
 	}

--- a/collectors/hca_test.go
+++ b/collectors/hca_test.go
@@ -24,12 +24,12 @@ import (
 
 var (
 	hcaDevices = []InfinibandDevice{
-		{Type: "CA", LID: "133", GUID: "0x7cfe9003003b4b96", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10, Name: "o0002",
+		{Type: "CA", LID: "133", GUID: "0x7cfe9003003b4b96", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10, Name: "o0002", PortName: "HCA-1",
 			Uplinks: map[string]InfinibandUplink{
 				"1": {Type: "SW", LID: "1719", PortNumber: "11", GUID: "0x7cfe9003009ce5b0", Name: "ib-i1l1s01"},
 			},
 		},
-		{Type: "CA", LID: "134", GUID: "0x7cfe9003003b4bde", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10, Name: "o0001",
+		{Type: "CA", LID: "134", GUID: "0x7cfe9003003b4bde", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10, Name: "o0001", PortName: "HCA-1",
 			Uplinks: map[string]InfinibandUplink{
 				"1": {Type: "SW", LID: "1719", PortNumber: "10", GUID: "0x7cfe9003009ce5b0", Name: "ib-i1l1s01"},
 			},
@@ -51,8 +51,8 @@ func TestHCACollector(t *testing.T) {
 		infiniband_exporter_collect_timeouts{collector="hca"} 0
 		# HELP infiniband_hca_info Infiniband HCA information
 		# TYPE infiniband_hca_info gauge
-		infiniband_hca_info{guid="0x7cfe9003003b4b96",hca="o0002",lid="133"} 1
-		infiniband_hca_info{guid="0x7cfe9003003b4bde",hca="o0001",lid="134"} 1
+		infiniband_hca_info{guid="0x7cfe9003003b4b96",hca="o0002",lid="133",port_name="HCA-1"} 1
+		infiniband_hca_info{guid="0x7cfe9003003b4bde",hca="o0001",lid="134",port_name="HCA-1"} 1
 		# HELP infiniband_hca_port_excessive_buffer_overrun_errors_total Infiniband HCA port ExcessiveBufferOverrunErrors
 		# TYPE infiniband_hca_port_excessive_buffer_overrun_errors_total counter
 		infiniband_hca_port_excessive_buffer_overrun_errors_total{guid="0x7cfe9003003b4b96",port="1"} 0
@@ -151,8 +151,8 @@ func TestHCACollector(t *testing.T) {
 		infiniband_hca_raw_rate_bytes_per_second{guid="0x7cfe9003003b4bde"} 1.2890625e+10
 		# HELP infiniband_hca_uplink_info Infiniband HCA uplink information
 		# TYPE infiniband_hca_uplink_info gauge
-		infiniband_hca_uplink_info{guid="0x7cfe9003003b4b96",hca="o0002",port="1",uplink="ib-i1l1s01",uplink_guid="0x7cfe9003009ce5b0",uplink_lid="1719",uplink_port="11",uplink_type="SW"} 1
-		infiniband_hca_uplink_info{guid="0x7cfe9003003b4bde",hca="o0001",port="1",uplink="ib-i1l1s01",uplink_guid="0x7cfe9003009ce5b0",uplink_lid="1719",uplink_port="10",uplink_type="SW"} 1
+		infiniband_hca_uplink_info{guid="0x7cfe9003003b4b96",hca="o0002",port="1",uplink="ib-i1l1s01",uplink_guid="0x7cfe9003009ce5b0",uplink_lid="1719",uplink_port="11",uplink_port_name="",uplink_type="SW"} 1
+		infiniband_hca_uplink_info{guid="0x7cfe9003003b4bde",hca="o0001",port="1",uplink="ib-i1l1s01",uplink_guid="0x7cfe9003009ce5b0",uplink_lid="1719",uplink_port="10",uplink_port_name="",uplink_type="SW"} 1
 	`
 	collector := NewHCACollector(&hcaDevices, false, log.NewNopLogger())
 	gatherers := setupGatherer(collector)
@@ -194,8 +194,8 @@ func TestHCACollectorFull(t *testing.T) {
 		infiniband_exporter_collect_timeouts{collector="hca"} 0
 		# HELP infiniband_hca_info Infiniband HCA information
 		# TYPE infiniband_hca_info gauge
-		infiniband_hca_info{guid="0x7cfe9003003b4b96",hca="o0002",lid="133"} 1
-		infiniband_hca_info{guid="0x7cfe9003003b4bde",hca="o0001",lid="134"} 1
+		infiniband_hca_info{guid="0x7cfe9003003b4b96",hca="o0002",lid="133",port_name="HCA-1"} 1
+		infiniband_hca_info{guid="0x7cfe9003003b4bde",hca="o0001",lid="134",port_name="HCA-1"} 1
 		# HELP infiniband_hca_port_buffer_overrun_errors_total Infiniband HCA port PortBufferOverrunErrors
 		# TYPE infiniband_hca_port_buffer_overrun_errors_total counter
 		infiniband_hca_port_buffer_overrun_errors_total{guid="0x7cfe9003003b4b96",port="1"} 0
@@ -318,8 +318,8 @@ func TestHCACollectorFull(t *testing.T) {
 		infiniband_hca_raw_rate_bytes_per_second{guid="0x7cfe9003003b4bde"} 1.2890625e+10
 		# HELP infiniband_hca_uplink_info Infiniband HCA uplink information
 		# TYPE infiniband_hca_uplink_info gauge
-		infiniband_hca_uplink_info{guid="0x7cfe9003003b4b96",hca="o0002",port="1",uplink="ib-i1l1s01",uplink_guid="0x7cfe9003009ce5b0",uplink_lid="1719",uplink_port="11",uplink_type="SW"} 1
-		infiniband_hca_uplink_info{guid="0x7cfe9003003b4bde",hca="o0001",port="1",uplink="ib-i1l1s01",uplink_guid="0x7cfe9003009ce5b0",uplink_lid="1719",uplink_port="10",uplink_type="SW"} 1
+		infiniband_hca_uplink_info{guid="0x7cfe9003003b4b96",hca="o0002",port="1",uplink="ib-i1l1s01",uplink_guid="0x7cfe9003009ce5b0",uplink_lid="1719",uplink_port="11",uplink_port_name="",uplink_type="SW"} 1
+		infiniband_hca_uplink_info{guid="0x7cfe9003003b4bde",hca="o0001",port="1",uplink="ib-i1l1s01",uplink_guid="0x7cfe9003009ce5b0",uplink_lid="1719",uplink_port="10",uplink_port_name="",uplink_type="SW"} 1
 	`
 	collector := NewHCACollector(&hcaDevices, false, log.NewNopLogger())
 	gatherers := setupGatherer(collector)

--- a/collectors/switch.go
+++ b/collectors/switch.go
@@ -141,7 +141,7 @@ func NewSwitchCollector(devices *[]InfinibandDevice, runonce bool, logger log.Lo
 		RawRate: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "raw_rate_bytes_per_second"),
 			"Infiniband switch raw rate", []string{"guid"}, nil),
 		Uplink: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "uplink_info"),
-			"Infiniband switch uplink information", append(labels, []string{"switch", "uplink", "uplink_guid", "uplink_type", "uplink_port", "uplink_lid"}...), nil),
+			"Infiniband switch uplink information", append(labels, []string{"switch", "uplink", "uplink_guid", "uplink_type", "uplink_port", "uplink_port_name", "uplink_lid"}...), nil),
 		Info: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "info"),
 			"Infiniband switch information", []string{"guid", "switch", "lid"}, nil),
 	}
@@ -277,7 +277,7 @@ func (s *SwitchCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(s.RawRate, prometheus.GaugeValue, device.RawRate, device.GUID)
 			ch <- prometheus.MustNewConstMetric(s.Info, prometheus.GaugeValue, 1, device.GUID, device.Name, device.LID)
 			for port, uplink := range device.Uplinks {
-				ch <- prometheus.MustNewConstMetric(s.Uplink, prometheus.GaugeValue, 1, device.GUID, port, device.Name, uplink.Name, uplink.GUID, uplink.Type, uplink.PortNumber, uplink.LID)
+				ch <- prometheus.MustNewConstMetric(s.Uplink, prometheus.GaugeValue, 1, device.GUID, port, device.Name, uplink.Name, uplink.GUID, uplink.Type, uplink.PortNumber, uplink.PortName, uplink.LID)
 			}
 		}
 	}

--- a/collectors/switch_test.go
+++ b/collectors/switch_test.go
@@ -158,10 +158,10 @@ func TestSwitchCollector(t *testing.T) {
 		infiniband_switch_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0"} 1.2890625e+10
 		# HELP infiniband_switch_uplink_info Infiniband switch uplink information
 		# TYPE infiniband_switch_uplink_info gauge
-		infiniband_switch_uplink_info{guid="0x506b4b03005c2740",port="35",switch="ib-i4l1s01",uplink="p0001",uplink_guid="0x506b4b0300cc02a6",uplink_lid="1432",uplink_port="1",uplink_type="CA"} 1
-		infiniband_switch_uplink_info{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01",uplink="ib-i1l2s01",uplink_guid="0x7cfe900300b07320",uplink_lid="1516",uplink_port="1",uplink_type="SW"} 1
-		infiniband_switch_uplink_info{guid="0x7cfe9003009ce5b0",port="10",switch="ib-i1l1s01",uplink="o0001",uplink_guid="0x7cfe9003003b4bde",uplink_lid="134",uplink_port="1",uplink_type="CA"} 1
-		infiniband_switch_uplink_info{guid="0x7cfe9003009ce5b0",port="11",switch="ib-i1l1s01",uplink="o0002",uplink_guid="0x7cfe9003003b4b96",uplink_lid="133",uplink_port="1",uplink_type="CA"} 1
+		infiniband_switch_uplink_info{guid="0x506b4b03005c2740",port="35",switch="ib-i4l1s01",uplink="p0001",uplink_guid="0x506b4b0300cc02a6",uplink_lid="1432",uplink_port="1",uplink_port_name="HCA-1",uplink_type="CA"} 1
+		infiniband_switch_uplink_info{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01",uplink="ib-i1l2s01",uplink_guid="0x7cfe900300b07320",uplink_lid="1516",uplink_port="1",uplink_port_name="",uplink_type="SW"} 1
+		infiniband_switch_uplink_info{guid="0x7cfe9003009ce5b0",port="10",switch="ib-i1l1s01",uplink="o0001",uplink_guid="0x7cfe9003003b4bde",uplink_lid="134",uplink_port="1",uplink_port_name="HCA-1",uplink_type="CA"} 1
+		infiniband_switch_uplink_info{guid="0x7cfe9003009ce5b0",port="11",switch="ib-i1l1s01",uplink="o0002",uplink_guid="0x7cfe9003003b4b96",uplink_lid="133",uplink_port="1",uplink_port_name="HCA-1",uplink_type="CA"} 1
 	`
 	collector := NewSwitchCollector(&switchDevices, false, log.NewNopLogger())
 	gatherers := setupGatherer(collector)
@@ -355,10 +355,10 @@ func TestSwitchCollectorFull(t *testing.T) {
 		infiniband_switch_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0"} 1.2890625e+10
 		# HELP infiniband_switch_uplink_info Infiniband switch uplink information
 		# TYPE infiniband_switch_uplink_info gauge
-		infiniband_switch_uplink_info{guid="0x506b4b03005c2740",port="35",switch="ib-i4l1s01",uplink="p0001",uplink_guid="0x506b4b0300cc02a6",uplink_lid="1432",uplink_port="1",uplink_type="CA"} 1
-		infiniband_switch_uplink_info{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01",uplink="ib-i1l2s01",uplink_guid="0x7cfe900300b07320",uplink_lid="1516",uplink_port="1",uplink_type="SW"} 1
-		infiniband_switch_uplink_info{guid="0x7cfe9003009ce5b0",port="10",switch="ib-i1l1s01",uplink="o0001",uplink_guid="0x7cfe9003003b4bde",uplink_lid="134",uplink_port="1",uplink_type="CA"} 1
-		infiniband_switch_uplink_info{guid="0x7cfe9003009ce5b0",port="11",switch="ib-i1l1s01",uplink="o0002",uplink_guid="0x7cfe9003003b4b96",uplink_lid="133",uplink_port="1",uplink_type="CA"} 1
+		infiniband_switch_uplink_info{guid="0x506b4b03005c2740",port="35",switch="ib-i4l1s01",uplink="p0001",uplink_guid="0x506b4b0300cc02a6",uplink_lid="1432",uplink_port="1",uplink_port_name="HCA-1",uplink_type="CA"} 1
+		infiniband_switch_uplink_info{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01",uplink="ib-i1l2s01",uplink_guid="0x7cfe900300b07320",uplink_lid="1516",uplink_port="1",uplink_port_name="",uplink_type="SW"} 1
+		infiniband_switch_uplink_info{guid="0x7cfe9003009ce5b0",port="10",switch="ib-i1l1s01",uplink="o0001",uplink_guid="0x7cfe9003003b4bde",uplink_lid="134",uplink_port="1",uplink_port_name="HCA-1",uplink_type="CA"} 1
+		infiniband_switch_uplink_info{guid="0x7cfe9003009ce5b0",port="11",switch="ib-i1l1s01",uplink="o0002",uplink_guid="0x7cfe9003003b4b96",uplink_lid="133",uplink_port="1",uplink_port_name="HCA-1",uplink_type="CA"} 1
 	`
 	collector := NewSwitchCollector(&switchDevices, false, log.NewNopLogger())
 	gatherers := setupGatherer(collector)

--- a/infiniband_exporter_test.go
+++ b/infiniband_exporter_test.go
@@ -159,10 +159,10 @@ infiniband_switch_raw_rate_bytes_per_second{guid="0x506b4b03005c2740"} 1.2890625
 infiniband_switch_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0"} 1.2890625e+10
 # HELP infiniband_switch_uplink_info Infiniband switch uplink information
 # TYPE infiniband_switch_uplink_info gauge
-infiniband_switch_uplink_info{guid="0x506b4b03005c2740",port="35",switch="ib-i4l1s01",uplink="p0001",uplink_guid="0x506b4b0300cc02a6",uplink_lid="1432",uplink_port="1",uplink_type="CA"} 1
-infiniband_switch_uplink_info{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01",uplink="ib-i1l2s01",uplink_guid="0x7cfe900300b07320",uplink_lid="1516",uplink_port="1",uplink_type="SW"} 1
-infiniband_switch_uplink_info{guid="0x7cfe9003009ce5b0",port="10",switch="ib-i1l1s01",uplink="o0001",uplink_guid="0x7cfe9003003b4bde",uplink_lid="134",uplink_port="1",uplink_type="CA"} 1
-infiniband_switch_uplink_info{guid="0x7cfe9003009ce5b0",port="11",switch="ib-i1l1s01",uplink="o0002",uplink_guid="0x7cfe9003003b4b96",uplink_lid="133",uplink_port="1",uplink_type="CA"} 1`
+infiniband_switch_uplink_info{guid="0x506b4b03005c2740",port="35",switch="ib-i4l1s01",uplink="p0001",uplink_guid="0x506b4b0300cc02a6",uplink_lid="1432",uplink_port="1",uplink_port_name="HCA-1",uplink_type="CA"} 1
+infiniband_switch_uplink_info{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01",uplink="ib-i1l2s01",uplink_guid="0x7cfe900300b07320",uplink_lid="1516",uplink_port="1",uplink_port_name="",uplink_type="SW"} 1
+infiniband_switch_uplink_info{guid="0x7cfe9003009ce5b0",port="10",switch="ib-i1l1s01",uplink="o0001",uplink_guid="0x7cfe9003003b4bde",uplink_lid="134",uplink_port="1",uplink_port_name="HCA-1",uplink_type="CA"} 1
+infiniband_switch_uplink_info{guid="0x7cfe9003009ce5b0",port="11",switch="ib-i1l1s01",uplink="o0002",uplink_guid="0x7cfe9003003b4b96",uplink_lid="133",uplink_port="1",uplink_port_name="HCA-1",uplink_type="CA"} 1`
 	expectedIbswinfo = `# HELP infiniband_switch_fan_rpm Infiniband switch fan RPM
 # TYPE infiniband_switch_fan_rpm gauge
 infiniband_switch_fan_rpm{fan="1",guid="0x506b4b03005c2740"} 6125
@@ -220,9 +220,9 @@ infiniband_switch_temperature_celsius{guid="0x506b4b03005c2740"} 53
 infiniband_switch_temperature_celsius{guid="0x7cfe9003009ce5b0"} 45`
 	expectedHCA = `# HELP infiniband_hca_info Infiniband HCA information
 # TYPE infiniband_hca_info gauge
-infiniband_hca_info{guid="0x506b4b0300cc02a6",hca="p0001",lid="1432"} 1
-infiniband_hca_info{guid="0x7cfe9003003b4b96",hca="o0002",lid="133"} 1
-infiniband_hca_info{guid="0x7cfe9003003b4bde",hca="o0001",lid="134"} 1
+infiniband_hca_info{guid="0x506b4b0300cc02a6",hca="p0001",lid="1432",port_name="HCA-1"} 1
+infiniband_hca_info{guid="0x7cfe9003003b4b96",hca="o0002",lid="133",port_name="HCA-1"} 1
+infiniband_hca_info{guid="0x7cfe9003003b4bde",hca="o0001",lid="134",port_name="HCA-1"} 1
 # HELP infiniband_hca_port_excessive_buffer_overrun_errors_total Infiniband HCA port ExcessiveBufferOverrunErrors
 # TYPE infiniband_hca_port_excessive_buffer_overrun_errors_total counter
 infiniband_hca_port_excessive_buffer_overrun_errors_total{guid="0x7cfe9003003b4b96",port="1"} 0
@@ -323,9 +323,9 @@ infiniband_hca_raw_rate_bytes_per_second{guid="0x7cfe9003003b4b96"} 1.2890625e+1
 infiniband_hca_raw_rate_bytes_per_second{guid="0x7cfe9003003b4bde"} 1.2890625e+10
 # HELP infiniband_hca_uplink_info Infiniband HCA uplink information
 # TYPE infiniband_hca_uplink_info gauge
-infiniband_hca_uplink_info{guid="0x506b4b0300cc02a6",hca="p0001",port="1",uplink="ib-i4l1s01",uplink_guid="0x506b4b03005c2740",uplink_lid="2052",uplink_port="35",uplink_type="SW"} 1
-infiniband_hca_uplink_info{guid="0x7cfe9003003b4b96",hca="o0002",port="1",uplink="ib-i1l1s01",uplink_guid="0x7cfe9003009ce5b0",uplink_lid="1719",uplink_port="11",uplink_type="SW"} 1
-infiniband_hca_uplink_info{guid="0x7cfe9003003b4bde",hca="o0001",port="1",uplink="ib-i1l1s01",uplink_guid="0x7cfe9003009ce5b0",uplink_lid="1719",uplink_port="10",uplink_type="SW"} 1`
+infiniband_hca_uplink_info{guid="0x506b4b0300cc02a6",hca="p0001",port="1",uplink="ib-i4l1s01",uplink_guid="0x506b4b03005c2740",uplink_lid="2052",uplink_port="35",uplink_port_name="",uplink_type="SW"} 1
+infiniband_hca_uplink_info{guid="0x7cfe9003003b4b96",hca="o0002",port="1",uplink="ib-i1l1s01",uplink_guid="0x7cfe9003009ce5b0",uplink_lid="1719",uplink_port="11",uplink_port_name="",uplink_type="SW"} 1
+infiniband_hca_uplink_info{guid="0x7cfe9003003b4bde",hca="o0001",port="1",uplink="ib-i1l1s01",uplink_guid="0x7cfe9003009ce5b0",uplink_lid="1719",uplink_port="10",uplink_port_name="",uplink_type="SW"} 1`
 	expectedSwitchNoError = `# HELP infiniband_exporter_collect_errors Number of errors that occurred during collection
 # TYPE infiniband_exporter_collect_errors gauge
 infiniband_exporter_collect_errors{collector="ibnetdiscover-runonce"} 0


### PR DESCRIPTION
- Add "uplink_port_name" label to infiniband_hca_uplink_info
- Add "port_name" label to infiniband_hca_info
- Add "uplink_port_name" label to infiniband_switch_uplink_info