### PR TITLE
RPM Spec File and Systemd Templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Install compiled binaries after extracting tar.gz from release page.
 cp /tmp/infiniband_exporter /usr/sbin/infiniband_exporter
 ```
 
-Add systemd unit file and start service. Modify the `ExecStart` or `/etc/sysconfig/infiniband_exporter` with desired flags.
+Add systemd unit file and start service. Modify the `ExecStart` or `OPTIONS` in `/etc/sysconfig/infiniband_exporter` with desired flags.
 The unit file uses [systemd's service templating feature](https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Service%20Templates) and [specifiers](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Specifiers).
 ```
 cp systemd/infiniband_exporter@.service /etc/systemd/system/infiniband_exporter@.service

--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ systemctl daemon-reload
 systemctl start infiniband_exporter
 ```
 
+## Using the service file
+Uses [systemd's service templating feature](https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Service%20Templates) and [specifiers](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Specifiers).
+
+```
+# Run as root
+systemctl start infiniband_exporter@root.service
+# Run as non-root, requires adding --sudo to options and other sudo steps above
+systemctl start infiniband_exporter@infiniband_exporter.service
+```
+
 ## Build from source
 
 To produce the `infiniband_exporter` binary:

--- a/README.md
+++ b/README.md
@@ -101,24 +101,14 @@ useradd -r -d /var/lib/infiniband_exporter -s /sbin/nologin -M -g infiniband_exp
 Install compiled binaries after extracting tar.gz from release page.
 
 ```
-cp /tmp/infiniband_exporter /usr/local/bin/infiniband_exporter
+cp /tmp/infiniband_exporter /usr/sbin/infiniband_exporter
 ```
 
-Add systemd unit file and start service. Modify the `ExecStart` with desired flags.
-
+Add systemd unit file and start service. Modify the `ExecStart` or `/etc/sysconfig/infiniband_exporter` with desired flags.
+The unit file uses [systemd's service templating feature](https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Service%20Templates) and [specifiers](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Specifiers).
 ```
-cp systemd/infiniband_exporter.service /etc/systemd/system/infiniband_exporter.service
+cp systemd/infiniband_exporter@.service /etc/systemd/system/infiniband_exporter@.service
 systemctl daemon-reload
-systemctl start infiniband_exporter
-```
-
-## Using the service file
-Uses [systemd's service templating feature](https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Service%20Templates) and [specifiers](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Specifiers).
-
-```
-# Run as root
-systemctl start infiniband_exporter@root.service
-# Run as non-root, requires adding --sudo to options and other sudo steps above
 systemctl start infiniband_exporter@infiniband_exporter.service
 ```
 

--- a/infiniband_exporter.spec
+++ b/infiniband_exporter.spec
@@ -25,7 +25,7 @@ make build
 
 %install
 install -Dpm 0755 %{name} %{buildroot}%{_sbindir}/%{name}
-install -Dpm 0644 systemd/%{name}@.service %{buildroot}%{_unitdir}/%{name}.service
+install -Dpm 0644 systemd/%{name}@.service %{buildroot}%{_unitdir}/%{name}@.service
 install -Dpm 0644 systemd/%{name}.sysconfig %{buildroot}%{_sysconfdir}/sysconfig/%{name}
 
 %clean

--- a/infiniband_exporter.spec
+++ b/infiniband_exporter.spec
@@ -7,7 +7,7 @@ License:        Apache License
 Source0:        %{name}-%{version}.tar.gz
 URL:            https://github.com/treydock/infiniband_exporter
 
-Requires:       systemd datacenter-gpu-manager
+Requires:       infiniband-diags
 
 %description
 

--- a/infiniband_exporter.spec
+++ b/infiniband_exporter.spec
@@ -1,5 +1,5 @@
 Name:           infiniband_exporter
-Version:        0.10.0-rc1
+Version:        0.10.0
 Release:        1
 Summary:        The InfiniBand exporter collects counters from InfiniBand switches and HCAs
 

--- a/infiniband_exporter.spec
+++ b/infiniband_exporter.spec
@@ -1,0 +1,44 @@
+Name:           infiniband_exporter
+Version:        0.10.0-rc1
+Release:        1
+Summary:        The InfiniBand exporter collects counters from InfiniBand switches and HCAs
+
+License:        Apache License
+Source0:        %{name}-%{version}.tar.gz
+URL:            https://github.com/treydock/infiniband_exporter
+
+Requires:       systemd datacenter-gpu-manager
+
+%description
+
+The InfiniBand exporter collects counters from InfiniBand switches and HCAs
+
+This exporter listens on port 9315 by default and all metrics are exposed via the /metrics endpoint.
+
+%global debug_package %{nil}
+
+%prep
+%autosetup
+
+%build
+make build
+
+%install
+install -Dpm 0755 %{name} %{buildroot}%{_sbindir}/%{name}
+install -Dpm 0644 systemd/%{name}@.service %{buildroot}%{_unitdir}/%{name}.service
+install -Dpm 0644 systemd/%{name}.sysconfig %{buildroot}%{_sysconfdir}/sysconfig/%{name}
+
+%clean
+rm -rf %{buildroot}
+
+%pre
+%{_sbindir}/useradd -c "%{name} user" -s /bin/false -r -d / %{name} 2>/dev/null || :
+
+%files
+%{_sbindir}/%{name}
+%{_unitdir}/%{name}@.service
+%config(noreplace) %{_sysconfdir}/sysconfig/%{name}
+
+%changelog
+* Tue Jul 2 2024 Initial RPM
+- 

--- a/systemd/infiniband_exporter.sysconfig
+++ b/systemd/infiniband_exporter.sysconfig
@@ -1,0 +1,1 @@
+OPTIONS="--web.listen-address=:9315"

--- a/systemd/infiniband_exporter@.service
+++ b/systemd/infiniband_exporter@.service
@@ -4,8 +4,11 @@ Wants=basic.target
 After=basic.target network.target
 
 [Service]
-ExecStart=/usr/local/bin/infiniband_exporter --web.listen-address=:9315
+EnvironmentFile=-/etc/sysconfig/infiniband_exporter
+ExecStart=/usr/local/bin/infiniband_exporter $OPTIONS
 ExecReload=/bin/kill -HUP $MAINPID
+User=%I
+Group=%I
 KillMode=process
 Restart=always
 

--- a/systemd/infiniband_exporter@.service
+++ b/systemd/infiniband_exporter@.service
@@ -5,7 +5,7 @@ After=basic.target network.target
 
 [Service]
 EnvironmentFile=-/etc/sysconfig/infiniband_exporter
-ExecStart=/usr/local/bin/infiniband_exporter $OPTIONS
+ExecStart=/usr/sbin/infiniband_exporter $OPTIONS
 ExecReload=/bin/kill -HUP $MAINPID
 User=%I
 Group=%I


### PR DESCRIPTION
The PR includes and RPM spec file for building this as an RPM via `rpmbuild`.

It also includes changes for using systemd to run this exporter as a service. These changes allow the user to run the exporter as root or as a custom user that has been granted the correct sudo privileges as described. 