### PR TITLE
Associate switch rate with port

### DIFF
--- a/collectors/collectors_test.go
+++ b/collectors/collectors_test.go
@@ -30,16 +30,16 @@ var (
 	mockedStdout     string
 	_, cancel        = context.WithTimeout(context.Background(), 5*time.Second)
 	switchDevices    = []InfinibandDevice{
-		{Type: "SW", LID: "2052", GUID: "0x506b4b03005c2740", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10, Name: "ib-i4l1s01",
+		{Type: "SW", LID: "2052", GUID: "0x506b4b03005c2740", Name: "ib-i4l1s01",
 			Uplinks: map[string]InfinibandUplink{
-				"35": {Type: "CA", LID: "1432", PortNumber: "1", GUID: "0x506b4b0300cc02a6", Name: "p0001 HCA-1"},
+				"35": {Type: "CA", LID: "1432", PortNumber: "1", GUID: "0x506b4b0300cc02a6", Name: "p0001 HCA-1", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10},
 			},
 		},
-		{Type: "SW", LID: "1719", GUID: "0x7cfe9003009ce5b0", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10, Name: "ib-i1l1s01",
+		{Type: "SW", LID: "1719", GUID: "0x7cfe9003009ce5b0", Name: "ib-i1l1s01",
 			Uplinks: map[string]InfinibandUplink{
-				"1":  {Type: "SW", LID: "1516", PortNumber: "1", GUID: "0x7cfe900300b07320", Name: "ib-i1l2s01"},
-				"10": {Type: "CA", LID: "134", PortNumber: "1", GUID: "0x7cfe9003003b4bde", Name: "o0001 HCA-1"},
-				"11": {Type: "CA", LID: "133", PortNumber: "1", GUID: "0x7cfe9003003b4b96", Name: "o0002 HCA-1"},
+				"1":  {Type: "SW", LID: "1516", PortNumber: "1", GUID: "0x7cfe900300b07320", Name: "ib-i1l2s01", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10},
+				"10": {Type: "CA", LID: "134", PortNumber: "1", GUID: "0x7cfe9003003b4bde", Name: "o0001 HCA-1", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10},
+				"11": {Type: "CA", LID: "133", PortNumber: "1", GUID: "0x7cfe9003003b4b96", Name: "o0002 HCA-1", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10},
 			},
 		},
 	}

--- a/collectors/ibnetdiscover_test.go
+++ b/collectors/ibnetdiscover_test.go
@@ -135,32 +135,32 @@ func TestIbnetdiscoverParse(t *testing.T) {
 	expectedHCAs := []InfinibandDevice{
 		{Type: "CA", LID: "1432", GUID: "0x506b4b0300cc02a6", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10, Name: "p0001 HCA-1",
 			Uplinks: map[string]InfinibandUplink{
-				"1": {Type: "SW", LID: "2052", PortNumber: "35", GUID: "0x506b4b03005c2740", Name: "ib-i4l1s01"},
+				"1": {Type: "SW", LID: "2052", PortNumber: "35", GUID: "0x506b4b03005c2740", Name: "ib-i4l1s01", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10},
 			},
 		},
 		{Type: "CA", LID: "133", GUID: "0x7cfe9003003b4b96", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10, Name: "o0002 HCA-1",
 			Uplinks: map[string]InfinibandUplink{
-				"1": {Type: "SW", LID: "1719", PortNumber: "11", GUID: "0x7cfe9003009ce5b0", Name: "ib-i1l1s01"},
+				"1": {Type: "SW", LID: "1719", PortNumber: "11", GUID: "0x7cfe9003009ce5b0", Name: "ib-i1l1s01", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10},
 			},
 		},
 		{Type: "CA", LID: "134", GUID: "0x7cfe9003003b4bde", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10, Name: "o0001 HCA-1",
 			Uplinks: map[string]InfinibandUplink{
-				"1": {Type: "SW", LID: "1719", PortNumber: "10", GUID: "0x7cfe9003009ce5b0", Name: "ib-i1l1s01"},
+				"1": {Type: "SW", LID: "1719", PortNumber: "10", GUID: "0x7cfe9003009ce5b0", Name: "ib-i1l1s01", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10},
 			},
 		},
 	}
 
 	expectSwitches := []InfinibandDevice{
-		{Type: "SW", LID: "2052", GUID: "0x506b4b03005c2740", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10, Name: "ib-i4l1s01",
+		{Type: "SW", LID: "2052", GUID: "0x506b4b03005c2740", Name: "ib-i4l1s01",
 			Uplinks: map[string]InfinibandUplink{
-				"35": {Type: "CA", LID: "1432", PortNumber: "1", GUID: "0x506b4b0300cc02a6", Name: "p0001 HCA-1"},
+				"35": {Type: "CA", LID: "1432", PortNumber: "1", GUID: "0x506b4b0300cc02a6", Name: "p0001 HCA-1", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10},
 			},
 		},
-		{Type: "SW", LID: "1719", GUID: "0x7cfe9003009ce5b0", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10, Name: "ib-i1l1s01",
+		{Type: "SW", LID: "1719", GUID: "0x7cfe9003009ce5b0", Name: "ib-i1l1s01",
 			Uplinks: map[string]InfinibandUplink{
-				"1":  {Type: "SW", LID: "1516", PortNumber: "1", GUID: "0x7cfe900300b07320", Name: "ib-i1l2s01"},
-				"10": {Type: "CA", LID: "134", PortNumber: "1", GUID: "0x7cfe9003003b4bde", Name: "o0001 HCA-1"},
-				"11": {Type: "CA", LID: "133", PortNumber: "1", GUID: "0x7cfe9003003b4b96", Name: "o0002 HCA-1"},
+				"1":  {Type: "SW", LID: "1516", PortNumber: "1", GUID: "0x7cfe900300b07320", Name: "ib-i1l2s01", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10},
+				"10": {Type: "CA", LID: "134", PortNumber: "1", GUID: "0x7cfe9003003b4bde", Name: "o0001 HCA-1", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10},
+				"11": {Type: "CA", LID: "133", PortNumber: "1", GUID: "0x7cfe9003003b4b96", Name: "o0002 HCA-1", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10},
 			},
 		},
 	}
@@ -199,23 +199,23 @@ func TestIbnetdiscoverParse2(t *testing.T) {
 	expectedHCAs := []InfinibandDevice{
 		{Type: "CA", LID: "78", GUID: "0x946dae0300630bfe", Rate: 50 * 4 * 125000000, RawRate: 50 * 4 * 125000000, Name: "Mellanox Technologies Aggregation Node",
 			Uplinks: map[string]InfinibandUplink{
-				"1": {Type: "SW", LID: "51", PortNumber: "81", GUID: "0x946dae0300630bf6", Name: "5FB0405-leaf-IB01"},
+				"1": {Type: "SW", LID: "51", PortNumber: "81", GUID: "0x946dae0300630bf6", Name: "5FB0405-leaf-IB01", Rate: 50 * 4 * 125000000, RawRate: 50 * 4 * 125000000},
 			},
 		},
 		{Type: "CA", LID: "88", GUID: "0xb83fd20300da1138", Rate: 50 * 4 * 125000000, RawRate: 50 * 4 * 125000000, Name: "worker20 mlx5_3",
 			Uplinks: map[string]InfinibandUplink{
-				"1": {Type: "SW", LID: "51", PortNumber: "79", GUID: "0x946dae0300630bf6", Name: "5FB0405-leaf-IB01"},
+				"1": {Type: "SW", LID: "51", PortNumber: "79", GUID: "0x946dae0300630bf6", Name: "5FB0405-leaf-IB01", Rate: 50 * 4 * 125000000, RawRate: 50 * 4 * 125000000},
 			},
 		},
 	}
 
 	expectSwitches := []InfinibandDevice{
-		{Type: "SW", LID: "478", GUID: "0x0002c9020040f160", Rate: 8 * 4 * 125000000, RawRate: 10 * 4 * 125000000, Name: "Infiniscale-IV Mellanox Technologies",
+		{Type: "SW", LID: "478", GUID: "0x0002c9020040f160", Name: "Infiniscale-IV Mellanox Technologies",
 			Uplinks: map[string]InfinibandUplink{},
 		},
-		{Type: "SW", LID: "9", GUID: "0x946dae030053ec1a", Rate: 50 * 4 * 125000000, RawRate: 50 * 4 * 125000000, Name: "5FB0406-spine-IB03",
+		{Type: "SW", LID: "9", GUID: "0x946dae030053ec1a", Name: "5FB0406-spine-IB03",
 			Uplinks: map[string]InfinibandUplink{
-				"81": {Type: "CA", LID: "60", PortNumber: "1", GUID: "0x946dae0300630bfe", Name: "Mellanox Technologies Aggregation Node"},
+				"81": {Type: "CA", LID: "60", PortNumber: "1", GUID: "0x946dae0300630bfe", Name: "Mellanox Technologies Aggregation Node", Rate: 50 * 4 * 125000000, RawRate: 50 * 4 * 125000000},
 			},
 		},
 	}

--- a/collectors/switch.go
+++ b/collectors/switch.go
@@ -155,10 +155,10 @@ func NewSwitchCollector(devices *[]InfinibandDevice, runonce bool, logger log.Lo
 			"Infiniband switch port PortVLMappingErrors", labels, nil),
 		PortLoopingErrors: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "port_looping_errors_total"),
 			"Infiniband switch port PortLoopingErrors", labels, nil),
-		Rate: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "rate_bytes_per_second"),
-			"Infiniband switch rate", []string{"guid"}, nil),
-		RawRate: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "raw_rate_bytes_per_second"),
-			"Infiniband switch raw rate", []string{"guid"}, nil),
+		Rate: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "port_rate_bytes_per_second"),
+			"Infiniband switch port rate", labels, nil),
+		RawRate: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "port_raw_rate_bytes_per_second"),
+			"Infiniband switch port raw rate", labels, nil),
 		Uplink: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "uplink_info"),
 			"Infiniband switch uplink information", append(labels, []string{"switch", "uplink", "uplink_guid", "uplink_type", "uplink_port", "uplink_lid"}...), nil),
 		Info: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "info"),
@@ -296,13 +296,13 @@ func (s *SwitchCollector) Collect(ch chan<- prometheus.Metric) {
 	if *switchCollectBase {
 		for _, device := range *s.devices {
 			metric := metrics[device.GUID]
-			ch <- prometheus.MustNewConstMetric(s.Rate, prometheus.GaugeValue, device.Rate, device.GUID)
-			ch <- prometheus.MustNewConstMetric(s.RawRate, prometheus.GaugeValue, device.RawRate, device.GUID)
 			ch <- prometheus.MustNewConstMetric(s.Info, prometheus.GaugeValue, 1, device.GUID, device.Name, device.LID)
 			ch <- prometheus.MustNewConstMetric(s.Duration, prometheus.GaugeValue, metric.duration, device.GUID, s.collector)
 			ch <- prometheus.MustNewConstMetric(s.Timeout, prometheus.GaugeValue, metric.timeout, device.GUID, s.collector)
 			ch <- prometheus.MustNewConstMetric(s.Error, prometheus.GaugeValue, metric.error, device.GUID, s.collector)
 			for port, uplink := range device.Uplinks {
+				ch <- prometheus.MustNewConstMetric(s.Rate, prometheus.GaugeValue, uplink.Rate, device.GUID, port)
+				ch <- prometheus.MustNewConstMetric(s.RawRate, prometheus.GaugeValue, uplink.RawRate, device.GUID, port)
 				ch <- prometheus.MustNewConstMetric(s.Uplink, prometheus.GaugeValue, 1, device.GUID, port, device.Name, uplink.Name, uplink.GUID, uplink.Type, uplink.PortNumber, uplink.LID)
 			}
 		}

--- a/collectors/switch_test.go
+++ b/collectors/switch_test.go
@@ -73,6 +73,18 @@ func TestSwitchCollector(t *testing.T) {
 		infiniband_switch_port_qp1_dropped_total{guid="0x506b4b03005c2740",port="1"} 0
 		infiniband_switch_port_qp1_dropped_total{guid="0x7cfe9003009ce5b0",port="1"} 0
 		infiniband_switch_port_qp1_dropped_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		# HELP infiniband_switch_port_rate_bytes_per_second Infiniband switch port rate
+		# TYPE infiniband_switch_port_rate_bytes_per_second gauge
+		infiniband_switch_port_rate_bytes_per_second{guid="0x506b4b03005c2740",port="35"} 1.25e+10
+		infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="10"} 1.25e+10
+		infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="11"} 1.25e+10
+		infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="1"} 1.25e+10
+		# HELP infiniband_switch_port_raw_rate_bytes_per_second Infiniband switch port raw rate
+		# TYPE infiniband_switch_port_raw_rate_bytes_per_second gauge
+		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x506b4b03005c2740",port="35"} 1.2890625e+10
+		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="10"} 1.2890625e+10
+		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="11"} 1.2890625e+10
+		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="1"} 1.2890625e+10
 		# HELP infiniband_switch_port_receive_constraint_errors_total Infiniband switch port PortRcvConstraintErrors
 		# TYPE infiniband_switch_port_receive_constraint_errors_total counter
 		infiniband_switch_port_receive_constraint_errors_total{guid="0x506b4b03005c2740",port="1"} 0
@@ -148,14 +160,6 @@ func TestSwitchCollector(t *testing.T) {
 		infiniband_switch_port_vl15_dropped_total{guid="0x506b4b03005c2740",port="1"} 0
 		infiniband_switch_port_vl15_dropped_total{guid="0x7cfe9003009ce5b0",port="1"} 0
 		infiniband_switch_port_vl15_dropped_total{guid="0x7cfe9003009ce5b0",port="2"} 0
-		# HELP infiniband_switch_rate_bytes_per_second Infiniband switch rate
-		# TYPE infiniband_switch_rate_bytes_per_second gauge
-		infiniband_switch_rate_bytes_per_second{guid="0x506b4b03005c2740"} 1.25e+10
-		infiniband_switch_rate_bytes_per_second{guid="0x7cfe9003009ce5b0"} 1.25e+10
-		# HELP infiniband_switch_raw_rate_bytes_per_second Infiniband switch raw rate
-		# TYPE infiniband_switch_raw_rate_bytes_per_second gauge
-		infiniband_switch_raw_rate_bytes_per_second{guid="0x506b4b03005c2740"} 1.2890625e+10
-		infiniband_switch_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0"} 1.2890625e+10
 		# HELP infiniband_switch_uplink_info Infiniband switch uplink information
 		# TYPE infiniband_switch_uplink_info gauge
 		infiniband_switch_uplink_info{guid="0x506b4b03005c2740",port="35",switch="ib-i4l1s01",uplink="p0001 HCA-1",uplink_guid="0x506b4b0300cc02a6",uplink_lid="1432",uplink_port="1",uplink_type="CA"} 1
@@ -167,8 +171,8 @@ func TestSwitchCollector(t *testing.T) {
 	gatherers := setupGatherer(collector)
 	if val, err := testutil.GatherAndCount(gatherers); err != nil {
 		t.Errorf("Unexpected error: %v", err)
-	} else if val != 85 {
-		t.Errorf("Unexpected collection count %d, expected 85", val)
+	} else if val != 89 {
+		t.Errorf("Unexpected collection count %d, expected 89", val)
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
 		"infiniband_switch_port_excessive_buffer_overrun_errors_total", "infiniband_switch_port_link_downed_total",
@@ -183,7 +187,7 @@ func TestSwitchCollector(t *testing.T) {
 		"infiniband_switch_port_transmit_wait_total", "infiniband_switch_port_unicast_receive_packets_total",
 		"infiniband_switch_port_unicast_transmit_packets_total", "infiniband_switch_port_vl15_dropped_total",
 		"infiniband_switch_port_buffer_overrun_errors_total",
-		"infiniband_switch_info", "infiniband_switch_rate_bytes_per_second", "infiniband_switch_raw_rate_bytes_per_second", "infiniband_switch_uplink_info",
+		"infiniband_switch_info", "infiniband_switch_port_rate_bytes_per_second", "infiniband_switch_port_raw_rate_bytes_per_second", "infiniband_switch_uplink_info",
 		"infiniband_exporter_collect_errors", "infiniband_exporter_collect_timeouts"); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
@@ -265,6 +269,18 @@ func TestSwitchCollectorFull(t *testing.T) {
 		infiniband_switch_port_qp1_dropped_total{guid="0x506b4b03005c2740",port="1"} 0
 		infiniband_switch_port_qp1_dropped_total{guid="0x7cfe9003009ce5b0",port="1"} 0
 		infiniband_switch_port_qp1_dropped_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		# HELP infiniband_switch_port_rate_bytes_per_second Infiniband switch port rate
+		# TYPE infiniband_switch_port_rate_bytes_per_second gauge
+		infiniband_switch_port_rate_bytes_per_second{guid="0x506b4b03005c2740",port="35"} 1.25e+10
+		infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="10"} 1.25e+10
+		infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="11"} 1.25e+10
+		infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="1"} 1.25e+10
+		# HELP infiniband_switch_port_raw_rate_bytes_per_second Infiniband switch port raw rate
+		# TYPE infiniband_switch_port_raw_rate_bytes_per_second gauge
+		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x506b4b03005c2740",port="35"} 1.2890625e+10
+		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="10"} 1.2890625e+10
+		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="11"} 1.2890625e+10
+		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="1"} 1.2890625e+10
 		# HELP infiniband_switch_port_receive_constraint_errors_total Infiniband switch port PortRcvConstraintErrors
 		# TYPE infiniband_switch_port_receive_constraint_errors_total counter
 		infiniband_switch_port_receive_constraint_errors_total{guid="0x506b4b03005c2740",port="1"} 0
@@ -345,14 +361,6 @@ func TestSwitchCollectorFull(t *testing.T) {
 		infiniband_switch_port_vl15_dropped_total{guid="0x506b4b03005c2740",port="1"} 0
 		infiniband_switch_port_vl15_dropped_total{guid="0x7cfe9003009ce5b0",port="1"} 0
 		infiniband_switch_port_vl15_dropped_total{guid="0x7cfe9003009ce5b0",port="2"} 0
-		# HELP infiniband_switch_rate_bytes_per_second Infiniband switch rate
-		# TYPE infiniband_switch_rate_bytes_per_second gauge
-		infiniband_switch_rate_bytes_per_second{guid="0x506b4b03005c2740"} 1.25e+10
-		infiniband_switch_rate_bytes_per_second{guid="0x7cfe9003009ce5b0"} 1.25e+10
-		# HELP infiniband_switch_raw_rate_bytes_per_second Infiniband switch raw rate
-		# TYPE infiniband_switch_raw_rate_bytes_per_second gauge
-		infiniband_switch_raw_rate_bytes_per_second{guid="0x506b4b03005c2740"} 1.2890625e+10
-		infiniband_switch_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0"} 1.2890625e+10
 		# HELP infiniband_switch_uplink_info Infiniband switch uplink information
 		# TYPE infiniband_switch_uplink_info gauge
 		infiniband_switch_uplink_info{guid="0x506b4b03005c2740",port="35",switch="ib-i4l1s01",uplink="p0001 HCA-1",uplink_guid="0x506b4b0300cc02a6",uplink_lid="1432",uplink_port="1",uplink_type="CA"} 1
@@ -364,8 +372,8 @@ func TestSwitchCollectorFull(t *testing.T) {
 	gatherers := setupGatherer(collector)
 	if val, err := testutil.GatherAndCount(gatherers); err != nil {
 		t.Errorf("Unexpected error: %v", err)
-	} else if val != 109 {
-		t.Errorf("Unexpected collection count %d, expected 109", val)
+	} else if val != 113 {
+		t.Errorf("Unexpected collection count %d, expected 113", val)
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
 		"infiniband_switch_port_excessive_buffer_overrun_errors_total", "infiniband_switch_port_link_downed_total",
@@ -382,7 +390,7 @@ func TestSwitchCollectorFull(t *testing.T) {
 		"infiniband_switch_port_buffer_overrun_errors_total", "infiniband_switch_port_dli_mapping_errors_total",
 		"infiniband_switch_port_local_physical_errors_total", "infiniband_switch_port_looping_errors_total",
 		"infiniband_switch_port_malformed_packet_errors_total", "infiniband_switch_port_vl_mapping_errors_total",
-		"infiniband_switch_info", "infiniband_switch_rate_bytes_per_second", "infiniband_switch_raw_rate_bytes_per_second", "infiniband_switch_uplink_info",
+		"infiniband_switch_info", "infiniband_switch_port_rate_bytes_per_second", "infiniband_switch_port_raw_rate_bytes_per_second", "infiniband_switch_uplink_info",
 		"infiniband_exporter_collect_errors", "infiniband_exporter_collect_timeouts"); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
@@ -453,7 +461,7 @@ func TestSwitchCollectorNoBase(t *testing.T) {
 		"infiniband_switch_port_buffer_overrun_errors_total", "infiniband_switch_port_dli_mapping_errors_total",
 		"infiniband_switch_port_local_physical_errors_total", "infiniband_switch_port_looping_errors_total",
 		"infiniband_switch_port_malformed_packet_errors_total", "infiniband_switch_port_vl_mapping_errors_total",
-		"infiniband_switch_info", "infiniband_switch_rate_bytes_per_second", "infiniband_switch_raw_rate_bytes_per_second", "infiniband_switch_uplink_info",
+		"infiniband_switch_info", "infiniband_switch_port_rate_bytes_per_second", "infiniband_switch_raw_port_rate_bytes_per_second", "infiniband_switch_uplink_info",
 		"infiniband_exporter_collect_errors", "infiniband_exporter_collect_timeouts"); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
@@ -476,8 +484,8 @@ func TestSwitchCollectorError(t *testing.T) {
 	gatherers := setupGatherer(collector)
 	if val, err := testutil.GatherAndCount(gatherers); err != nil {
 		t.Errorf("Unexpected error: %v", err)
-	} else if val != 19 {
-		t.Errorf("Unexpected collection count %d, expected 19", val)
+	} else if val != 23 {
+		t.Errorf("Unexpected collection count %d, expected 23", val)
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
 		"infiniband_switch_port_excessive_buffer_overrun_errors_total", "infiniband_switch_port_link_downed_total",
@@ -504,8 +512,8 @@ func TestSwitchCollectorErrorRunonce(t *testing.T) {
 	gatherers := setupGatherer(collector)
 	if val, err := testutil.GatherAndCount(gatherers); err != nil {
 		t.Errorf("Unexpected error: %v", err)
-	} else if val != 20 {
-		t.Errorf("Unexpected collection count %d, expected 20", val)
+	} else if val != 24 {
+		t.Errorf("Unexpected collection count %d, expected 24", val)
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
 		"infiniband_switch_port_excessive_buffer_overrun_errors_total", "infiniband_switch_port_link_downed_total",
@@ -532,8 +540,8 @@ func TestSwitchCollectorTimeout(t *testing.T) {
 	gatherers := setupGatherer(collector)
 	if val, err := testutil.GatherAndCount(gatherers); err != nil {
 		t.Errorf("Unexpected error: %v", err)
-	} else if val != 19 {
-		t.Errorf("Unexpected collection count %d, expected 19", val)
+	} else if val != 23 {
+		t.Errorf("Unexpected collection count %d, expected 23", val)
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
 		"infiniband_switch_port_excessive_buffer_overrun_errors_total", "infiniband_switch_port_link_downed_total",

--- a/infiniband_exporter_test.go
+++ b/infiniband_exporter_test.go
@@ -74,6 +74,18 @@ infiniband_switch_port_multicast_transmit_packets_total{guid="0x7cfe9003009ce5b0
 infiniband_switch_port_qp1_dropped_total{guid="0x506b4b03005c2740",port="1"} 0
 infiniband_switch_port_qp1_dropped_total{guid="0x7cfe9003009ce5b0",port="1"} 0
 infiniband_switch_port_qp1_dropped_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+# HELP infiniband_switch_port_rate_bytes_per_second Infiniband switch port rate
+# TYPE infiniband_switch_port_rate_bytes_per_second gauge
+infiniband_switch_port_rate_bytes_per_second{guid="0x506b4b03005c2740",port="35"} 1.25e+10
+infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="1"} 1.25e+10
+infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="10"} 1.25e+10
+infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="11"} 1.25e+10
+# HELP infiniband_switch_port_raw_rate_bytes_per_second Infiniband switch port raw rate
+# TYPE infiniband_switch_port_raw_rate_bytes_per_second gauge
+infiniband_switch_port_raw_rate_bytes_per_second{guid="0x506b4b03005c2740",port="35"} 1.2890625e+10
+infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="1"} 1.2890625e+10
+infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="10"} 1.2890625e+10
+infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="11"} 1.2890625e+10
 # HELP infiniband_switch_port_receive_constraint_errors_total Infiniband switch port PortRcvConstraintErrors
 # TYPE infiniband_switch_port_receive_constraint_errors_total counter
 infiniband_switch_port_receive_constraint_errors_total{guid="0x506b4b03005c2740",port="1"} 0
@@ -149,14 +161,6 @@ infiniband_switch_port_unicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",
 infiniband_switch_port_vl15_dropped_total{guid="0x506b4b03005c2740",port="1"} 0
 infiniband_switch_port_vl15_dropped_total{guid="0x7cfe9003009ce5b0",port="1"} 0
 infiniband_switch_port_vl15_dropped_total{guid="0x7cfe9003009ce5b0",port="2"} 0
-# HELP infiniband_switch_rate_bytes_per_second Infiniband switch rate
-# TYPE infiniband_switch_rate_bytes_per_second gauge
-infiniband_switch_rate_bytes_per_second{guid="0x506b4b03005c2740"} 1.25e+10
-infiniband_switch_rate_bytes_per_second{guid="0x7cfe9003009ce5b0"} 1.25e+10
-# HELP infiniband_switch_raw_rate_bytes_per_second Infiniband switch raw rate
-# TYPE infiniband_switch_raw_rate_bytes_per_second gauge
-infiniband_switch_raw_rate_bytes_per_second{guid="0x506b4b03005c2740"} 1.2890625e+10
-infiniband_switch_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0"} 1.2890625e+10
 # HELP infiniband_switch_uplink_info Infiniband switch uplink information
 # TYPE infiniband_switch_uplink_info gauge
 infiniband_switch_uplink_info{guid="0x506b4b03005c2740",port="35",switch="ib-i4l1s01",uplink="p0001 HCA-1",uplink_guid="0x506b4b0300cc02a6",uplink_lid="1432",uplink_port="1",uplink_type="CA"} 1


### PR DESCRIPTION
* Replaces `infiniband_switch_rate_bytes_per_second` with `infiniband_switch_port_rate_bytes_per_second`
* Replaces `infiniband_switch_raw_rate_bytes_per_second` with `infiniband_switch_port_raw_rate_bytes_per_second`