### PR TITLE
Add 'switch' label containing hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,13 @@ Collectors are enabled or disabled via `--collector.<name>` and `--no-collector.
 Name | Description | Default
 -----|-------------|--------
 switch | Collect switch port counters | Enabled
+switch.base-metrics | Collect base switch metrics | Enabled
+switch.rcv-err-details | Collect receive error details | Disabled
+switch.port-state | Report switch port link state (1=up, 0=down) | Disabled
 ibswinfo | Collect data on unmanaged switches via ibswinfo (BETA) | Disabled
 hca | Collect HCA port counters | Disabled
+hca.base-metrics | Collect base HCA metrics | Enabled
+hca.rcv-err-details | Collect receive error details | Disabled
 
 If you have a node name map file typically used with Subnet Managers, you can provide that file to the  `--ibnetdiscover.node-name-map` flag.  This will use friendly names for switches.
 Even without this flag, exporter still adds the `switch` label populated with whatever hostname (or GUID-style placeholder) ibnetdiscover returns.
@@ -55,6 +60,14 @@ This feature is considered BETA as it relies on parsing non-machine readable dat
 In the future this exporter may collect the unmanaged switch information directly in a similar way to what ibswinfo is doing.
 
 The collection of `ibswinfo` takes about 2-3 seconds per switch so consider increasing Prometheus scrape timeout or running using `--exporter.runonce` per [Large fabric considerations](#large-fabric-considerations).  Also consider increasing the `--ibswinfo.max-concurrent` to a value greater than the default of 1, but be aware that a value too high will cause timeouts executing concurrent `ibswinfo` commands.
+
+### Port link state monitoring
+
+By default, when a port link goes down the exporter stops emitting metrics for that port (the time series becomes stale). This makes it difficult to alert on link failures in Prometheus.
+
+Enabling `--collector.switch.port-state` adds `infiniband_switch_port_state{guid, switch, port}` — a gauge that reports `1` when up, `0` when down. Disconnected ports (reported as `???` by `ibnetdiscover`) persistently emit `0` on every scrape.
+
+See `examples/infiniband.rules` for recording rules and alert examples.
 
 ### Large fabric considerations
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ ibswinfo | Collect data on unmanaged switches via ibswinfo (BETA) | Disabled
 hca | Collect HCA port counters | Disabled
 
 If you have a node name map file typically used with Subnet Managers, you can provide that file to the  `--ibnetdiscover.node-name-map` flag.  This will use friendly names for switches.
+Even without this flag, exporter still adds the `switch` label populated with whatever hostname (or GUID-style placeholder) ibnetdiscover returns.
 
 
 If you wish to run the exporter as a user other than root and do not want to use sudo, you must make the UMAD device read/write to all users with something like the following:
 
 ```
-$ cat /etc/udev/rules.d/99-ib.rules 
+$ cat /etc/udev/rules.d/99-ib.rules
 KERNEL=="umad*", NAME="infiniband/%k" MODE="0666"
 ```
 

--- a/collectors/collectors_test.go
+++ b/collectors/collectors_test.go
@@ -34,6 +34,7 @@ var (
 			Uplinks: map[string]InfinibandUplink{
 				"35": {Type: "CA", LID: "1432", PortNumber: "1", GUID: "0x506b4b0300cc02a6", Name: "p0001 HCA-1", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10},
 			},
+			DownPorts: []string{"37"},
 		},
 		{Type: "SW", LID: "1719", GUID: "0x7cfe9003009ce5b0", Name: "ib-i1l1s01",
 			Uplinks: map[string]InfinibandUplink{

--- a/collectors/ibnetdiscover.go
+++ b/collectors/ibnetdiscover.go
@@ -51,13 +51,14 @@ var (
 )
 
 type InfinibandDevice struct {
-	Type    string
-	LID     string
-	GUID    string
-	Rate    float64
-	RawRate float64
-	Name    string
-	Uplinks map[string]InfinibandUplink
+	Type      string
+	LID       string
+	GUID      string
+	Rate      float64
+	RawRate   float64
+	Name      string
+	Uplinks   map[string]InfinibandUplink
+	DownPorts []string
 }
 
 type InfinibandUplink struct {
@@ -137,7 +138,27 @@ func ibnetdiscoverParse(out string, logger log.Logger) (*[]InfinibandDevice, *[]
 			continue
 		}
 		if items[5] == "???" {
-			level.Debug(logger).Log("msg", "Skipping line that is not connected", "line", line)
+			if !*switchCollectPortState {
+				level.Debug(logger).Log("msg", "Skipping line that is not connected", "line", line)
+				continue
+			}
+			guid := items[3]
+			portNumber := items[2]
+			device, ok := devices[guid]
+			if !ok {
+				device.Uplinks = make(map[string]InfinibandUplink)
+			}
+			device.Type = items[0]
+			device.LID = items[1]
+			device.GUID = guid
+			portName, _, err := parseNames(line)
+			if err != nil {
+				level.Debug(logger).Log("msg", "Unable to parse name for down port, skipping", "line", line)
+				continue
+			}
+			device.Name = portName
+			device.DownPorts = append(device.DownPorts, portNumber)
+			devices[guid] = device
 			continue
 		}
 		// check the last item, because name may have space so that it is split into multiple items

--- a/collectors/ibnetdiscover_test.go
+++ b/collectors/ibnetdiscover_test.go
@@ -195,6 +195,34 @@ func TestIbnetdiscoverParse(t *testing.T) {
 	}
 }
 
+func TestIbnetdiscoverParsePortState(t *testing.T) {
+	*switchCollectPortState = true
+	defer func() { *switchCollectPortState = false }()
+	out, err := ReadFixture("ibnetdiscover", "test")
+	if err != nil {
+		t.Fatal("Unable to read fixture")
+	}
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+	switches, _, err := ibnetdiscoverParse(out, logger)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+		return
+	}
+	var found bool
+	for _, sw := range *switches {
+		if sw.GUID == "0x506b4b03005c2740" {
+			found = true
+			if len(sw.DownPorts) != 1 || sw.DownPorts[0] != "37" {
+				t.Errorf("Expected DownPorts [37], got %v", sw.DownPorts)
+			}
+		}
+	}
+	if !found {
+		t.Error("Switch 0x506b4b03005c2740 not found")
+	}
+}
+
 func TestIbnetdiscoverParse2(t *testing.T) {
 	expectedHCAs := []InfinibandDevice{
 		{Type: "CA", LID: "78", GUID: "0x946dae0300630bfe", Rate: 50 * 4 * 125000000, RawRate: 50 * 4 * 125000000, Name: "Mellanox Technologies Aggregation Node",

--- a/collectors/ibswinfo.go
+++ b/collectors/ibswinfo.go
@@ -95,29 +95,29 @@ func NewIbswinfoCollector(devices *[]InfinibandDevice, runonce bool, logger log.
 		logger:    log.With(logger, "collector", collector),
 		collector: collector,
 		Duration: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "collect_duration_seconds"),
-			"Duration of collection", []string{"guid", "collector"}, nil),
+			"Duration of collection", []string{"guid", "switch", "collector"}, nil),
 		Error: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "collect_error"),
-			"Indicates if collect error", []string{"guid", "collector"}, nil),
+			"Indicates if collect error", []string{"guid", "switch", "collector"}, nil),
 		Timeout: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "collect_timeout"),
-			"Indicates if collect timeout", []string{"guid", "collector"}, nil),
+			"Indicates if collect timeout", []string{"guid", "switch", "collector"}, nil),
 		HardwareInfo: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "hardware_info"),
 			"Infiniband switch hardware info", []string{"guid", "firmware_version", "psid", "part_number", "serial_number", "switch"}, nil),
 		Uptime: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "uptime_seconds"),
-			"Infiniband switch uptime in seconds", []string{"guid"}, nil),
+			"Infiniband switch uptime in seconds", []string{"guid", "switch"}, nil),
 		PowerSupplyStatus: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "power_supply_status_info"),
-			"Infiniband switch power supply status", []string{"guid", "psu", "status"}, nil),
+			"Infiniband switch power supply status", []string{"guid", "switch", "psu", "status"}, nil),
 		PowerSupplyDCPower: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "power_supply_dc_power_status_info"),
-			"Infiniband switch power supply DC power status", []string{"guid", "psu", "status"}, nil),
+			"Infiniband switch power supply DC power status", []string{"guid", "switch", "psu", "status"}, nil),
 		PowerSupplyFanStatus: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "power_supply_fan_status_info"),
-			"Infiniband switch power supply fan status", []string{"guid", "psu", "status"}, nil),
+			"Infiniband switch power supply fan status", []string{"guid", "switch", "psu", "status"}, nil),
 		PowerSupplyWatts: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "power_supply_watts"),
-			"Infiniband switch power supply watts", []string{"guid", "psu"}, nil),
+			"Infiniband switch power supply watts", []string{"guid", "switch", "psu"}, nil),
 		Temp: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "temperature_celsius"),
-			"Infiniband switch temperature celsius", []string{"guid"}, nil),
+			"Infiniband switch temperature celsius", []string{"guid", "switch"}, nil),
 		FanStatus: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "fan_status_info"),
-			"Infiniband switch fan status", []string{"guid", "status"}, nil),
+			"Infiniband switch fan status", []string{"guid", "switch", "status"}, nil),
 		FanRPM: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "fan_rpm"),
-			"Infiniband switch fan RPM", []string{"guid", "fan"}, nil),
+			"Infiniband switch fan RPM", []string{"guid", "switch", "fan"}, nil),
 	}
 }
 
@@ -144,33 +144,33 @@ func (s *IbswinfoCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, swinfo := range swinfos {
 		ch <- prometheus.MustNewConstMetric(s.HardwareInfo, prometheus.GaugeValue, 1, swinfo.device.GUID,
 			swinfo.FirmwareVersion, swinfo.PSID, swinfo.PartNumber, swinfo.SerialNumber, swinfo.device.Name)
-		ch <- prometheus.MustNewConstMetric(s.Uptime, prometheus.GaugeValue, swinfo.Uptime, swinfo.device.GUID)
-		ch <- prometheus.MustNewConstMetric(s.Duration, prometheus.GaugeValue, swinfo.duration, swinfo.device.GUID, s.collector)
-		ch <- prometheus.MustNewConstMetric(s.Error, prometheus.GaugeValue, swinfo.error, swinfo.device.GUID, s.collector)
-		ch <- prometheus.MustNewConstMetric(s.Timeout, prometheus.GaugeValue, swinfo.timeout, swinfo.device.GUID, s.collector)
+		ch <- prometheus.MustNewConstMetric(s.Uptime, prometheus.GaugeValue, swinfo.Uptime, swinfo.device.GUID, swinfo.device.Name)
+		ch <- prometheus.MustNewConstMetric(s.Duration, prometheus.GaugeValue, swinfo.duration, swinfo.device.GUID, swinfo.device.Name, s.collector)
+		ch <- prometheus.MustNewConstMetric(s.Error, prometheus.GaugeValue, swinfo.error, swinfo.device.GUID, swinfo.device.Name, s.collector)
+		ch <- prometheus.MustNewConstMetric(s.Timeout, prometheus.GaugeValue, swinfo.timeout, swinfo.device.GUID, swinfo.device.Name, s.collector)
 		for _, psu := range swinfo.PowerSupplies {
 			if psu.Status != "" {
-				ch <- prometheus.MustNewConstMetric(s.PowerSupplyStatus, prometheus.GaugeValue, 1, swinfo.device.GUID, psu.ID, psu.Status)
+				ch <- prometheus.MustNewConstMetric(s.PowerSupplyStatus, prometheus.GaugeValue, 1, swinfo.device.GUID, swinfo.device.Name, psu.ID, psu.Status)
 			}
 			if psu.DCPower != "" {
-				ch <- prometheus.MustNewConstMetric(s.PowerSupplyDCPower, prometheus.GaugeValue, 1, swinfo.device.GUID, psu.ID, psu.DCPower)
+				ch <- prometheus.MustNewConstMetric(s.PowerSupplyDCPower, prometheus.GaugeValue, 1, swinfo.device.GUID, swinfo.device.Name, psu.ID, psu.DCPower)
 			}
 			if psu.FanStatus != "" {
-				ch <- prometheus.MustNewConstMetric(s.PowerSupplyFanStatus, prometheus.GaugeValue, 1, swinfo.device.GUID, psu.ID, psu.FanStatus)
+				ch <- prometheus.MustNewConstMetric(s.PowerSupplyFanStatus, prometheus.GaugeValue, 1, swinfo.device.GUID, swinfo.device.Name, psu.ID, psu.FanStatus)
 			}
 			if !math.IsNaN(psu.PowerW) {
-				ch <- prometheus.MustNewConstMetric(s.PowerSupplyWatts, prometheus.GaugeValue, psu.PowerW, swinfo.device.GUID, psu.ID)
+				ch <- prometheus.MustNewConstMetric(s.PowerSupplyWatts, prometheus.GaugeValue, psu.PowerW, swinfo.device.GUID, swinfo.device.Name, psu.ID)
 			}
 		}
 		if !math.IsNaN(swinfo.Temp) {
-			ch <- prometheus.MustNewConstMetric(s.Temp, prometheus.GaugeValue, swinfo.Temp, swinfo.device.GUID)
+			ch <- prometheus.MustNewConstMetric(s.Temp, prometheus.GaugeValue, swinfo.Temp, swinfo.device.GUID, swinfo.device.Name)
 		}
 		if swinfo.FanStatus != "" {
-			ch <- prometheus.MustNewConstMetric(s.FanStatus, prometheus.GaugeValue, 1, swinfo.device.GUID, swinfo.FanStatus)
+			ch <- prometheus.MustNewConstMetric(s.FanStatus, prometheus.GaugeValue, 1, swinfo.device.GUID, swinfo.device.Name, swinfo.FanStatus)
 		}
 		for _, fan := range swinfo.Fans {
 			if !math.IsNaN(fan.RPM) {
-				ch <- prometheus.MustNewConstMetric(s.FanRPM, prometheus.GaugeValue, fan.RPM, swinfo.device.GUID, fan.ID)
+				ch <- prometheus.MustNewConstMetric(s.FanRPM, prometheus.GaugeValue, fan.RPM, swinfo.device.GUID, swinfo.device.Name, fan.ID)
 			}
 		}
 	}

--- a/collectors/ibswinfo_test.go
+++ b/collectors/ibswinfo_test.go
@@ -223,63 +223,63 @@ func TestIbswinfoCollector(t *testing.T) {
 		infiniband_exporter_collect_timeouts{collector="ibswinfo"} 0
 		# HELP infiniband_switch_fan_rpm Infiniband switch fan RPM
 		# TYPE infiniband_switch_fan_rpm gauge
-		infiniband_switch_fan_rpm{fan="1",guid="0x506b4b03005c2740"} 6125
-		infiniband_switch_fan_rpm{fan="1",guid="0x7cfe9003009ce5b0"} 8493
-		infiniband_switch_fan_rpm{fan="2",guid="0x506b4b03005c2740"} 5251
-		infiniband_switch_fan_rpm{fan="2",guid="0x7cfe9003009ce5b0"} 7349
-		infiniband_switch_fan_rpm{fan="3",guid="0x506b4b03005c2740"} 6013
-		infiniband_switch_fan_rpm{fan="3",guid="0x7cfe9003009ce5b0"} 8441
-		infiniband_switch_fan_rpm{fan="4",guid="0x506b4b03005c2740"} 5335
-		infiniband_switch_fan_rpm{fan="4",guid="0x7cfe9003009ce5b0"} 7270
-		infiniband_switch_fan_rpm{fan="5",guid="0x506b4b03005c2740"} 6068
-		infiniband_switch_fan_rpm{fan="5",guid="0x7cfe9003009ce5b0"} 8337
-		infiniband_switch_fan_rpm{fan="6",guid="0x506b4b03005c2740"} 5423
-		infiniband_switch_fan_rpm{fan="6",guid="0x7cfe9003009ce5b0"} 7156
-		infiniband_switch_fan_rpm{fan="7",guid="0x506b4b03005c2740"} 5854
-		infiniband_switch_fan_rpm{fan="7",guid="0x7cfe9003009ce5b0"} 8441
-		infiniband_switch_fan_rpm{fan="8",guid="0x506b4b03005c2740"} 5467
-		infiniband_switch_fan_rpm{fan="8",guid="0x7cfe9003009ce5b0"} 7232
-		infiniband_switch_fan_rpm{fan="9",guid="0x506b4b03005c2740"} 5906
+		infiniband_switch_fan_rpm{fan="1",guid="0x506b4b03005c2740",switch="ib-i4l1s01"} 6125
+		infiniband_switch_fan_rpm{fan="1",guid="0x7cfe9003009ce5b0",switch="ib-i1l1s01"} 8493
+		infiniband_switch_fan_rpm{fan="2",guid="0x506b4b03005c2740",switch="ib-i4l1s01"} 5251
+		infiniband_switch_fan_rpm{fan="2",guid="0x7cfe9003009ce5b0",switch="ib-i1l1s01"} 7349
+		infiniband_switch_fan_rpm{fan="3",guid="0x506b4b03005c2740",switch="ib-i4l1s01"} 6013
+		infiniband_switch_fan_rpm{fan="3",guid="0x7cfe9003009ce5b0",switch="ib-i1l1s01"} 8441
+		infiniband_switch_fan_rpm{fan="4",guid="0x506b4b03005c2740",switch="ib-i4l1s01"} 5335
+		infiniband_switch_fan_rpm{fan="4",guid="0x7cfe9003009ce5b0",switch="ib-i1l1s01"} 7270
+		infiniband_switch_fan_rpm{fan="5",guid="0x506b4b03005c2740",switch="ib-i4l1s01"} 6068
+		infiniband_switch_fan_rpm{fan="5",guid="0x7cfe9003009ce5b0",switch="ib-i1l1s01"} 8337
+		infiniband_switch_fan_rpm{fan="6",guid="0x506b4b03005c2740",switch="ib-i4l1s01"} 5423
+		infiniband_switch_fan_rpm{fan="6",guid="0x7cfe9003009ce5b0",switch="ib-i1l1s01"} 7156
+		infiniband_switch_fan_rpm{fan="7",guid="0x506b4b03005c2740",switch="ib-i4l1s01"} 5854
+		infiniband_switch_fan_rpm{fan="7",guid="0x7cfe9003009ce5b0",switch="ib-i1l1s01"} 8441
+		infiniband_switch_fan_rpm{fan="8",guid="0x506b4b03005c2740",switch="ib-i4l1s01"} 5467
+		infiniband_switch_fan_rpm{fan="8",guid="0x7cfe9003009ce5b0",switch="ib-i1l1s01"} 7232
+		infiniband_switch_fan_rpm{fan="9",guid="0x506b4b03005c2740",switch="ib-i4l1s01"} 5906
 		# HELP infiniband_switch_fan_status_info Infiniband switch fan status
 		# TYPE infiniband_switch_fan_status_info gauge
-		infiniband_switch_fan_status_info{guid="0x506b4b03005c2740",status="OK"} 1
-		infiniband_switch_fan_status_info{guid="0x7cfe9003009ce5b0",status="ERROR"} 1
+		infiniband_switch_fan_status_info{guid="0x506b4b03005c2740",status="OK",switch="ib-i4l1s01"} 1
+		infiniband_switch_fan_status_info{guid="0x7cfe9003009ce5b0",status="ERROR",switch="ib-i1l1s01"} 1
 		# HELP infiniband_switch_hardware_info Infiniband switch hardware info
 		# TYPE infiniband_switch_hardware_info gauge
 		infiniband_switch_hardware_info{firmware_version="11.2008.2102",guid="0x7cfe9003009ce5b0",part_number="MSB7790-ES2F",psid="MT_1880110032",serial_number="MT1943X00498",switch="ib-i1l1s01"} 1
 		infiniband_switch_hardware_info{firmware_version="27.2010.3118",guid="0x506b4b03005c2740",part_number="MQM8790-HS2F",psid="MT_0000000063",serial_number="MT2152T10239",switch="ib-i4l1s01"} 1
 		# HELP infiniband_switch_power_supply_dc_power_status_info Infiniband switch power supply DC power status
 		# TYPE infiniband_switch_power_supply_dc_power_status_info gauge
-		infiniband_switch_power_supply_dc_power_status_info{guid="0x506b4b03005c2740",psu="0",status="OK"} 1
-		infiniband_switch_power_supply_dc_power_status_info{guid="0x506b4b03005c2740",psu="1",status="OK"} 1
-		infiniband_switch_power_supply_dc_power_status_info{guid="0x7cfe9003009ce5b0",psu="0",status="OK"} 1
-		infiniband_switch_power_supply_dc_power_status_info{guid="0x7cfe9003009ce5b0",psu="1",status="OK"} 1
+		infiniband_switch_power_supply_dc_power_status_info{guid="0x506b4b03005c2740",psu="0",status="OK",switch="ib-i4l1s01"} 1
+		infiniband_switch_power_supply_dc_power_status_info{guid="0x506b4b03005c2740",psu="1",status="OK",switch="ib-i4l1s01"} 1
+		infiniband_switch_power_supply_dc_power_status_info{guid="0x7cfe9003009ce5b0",psu="0",status="OK",switch="ib-i1l1s01"} 1
+		infiniband_switch_power_supply_dc_power_status_info{guid="0x7cfe9003009ce5b0",psu="1",status="OK",switch="ib-i1l1s01"} 1
 		# HELP infiniband_switch_power_supply_fan_status_info Infiniband switch power supply fan status
 		# TYPE infiniband_switch_power_supply_fan_status_info gauge
-		infiniband_switch_power_supply_fan_status_info{guid="0x506b4b03005c2740",psu="0",status="OK"} 1
-		infiniband_switch_power_supply_fan_status_info{guid="0x506b4b03005c2740",psu="1",status="OK"} 1
-		infiniband_switch_power_supply_fan_status_info{guid="0x7cfe9003009ce5b0",psu="0",status="OK"} 1
-		infiniband_switch_power_supply_fan_status_info{guid="0x7cfe9003009ce5b0",psu="1",status="OK"} 1
+		infiniband_switch_power_supply_fan_status_info{guid="0x506b4b03005c2740",psu="0",status="OK",switch="ib-i4l1s01"} 1
+		infiniband_switch_power_supply_fan_status_info{guid="0x506b4b03005c2740",psu="1",status="OK",switch="ib-i4l1s01"} 1
+		infiniband_switch_power_supply_fan_status_info{guid="0x7cfe9003009ce5b0",psu="0",status="OK",switch="ib-i1l1s01"} 1
+		infiniband_switch_power_supply_fan_status_info{guid="0x7cfe9003009ce5b0",psu="1",status="OK",switch="ib-i1l1s01"} 1
 		# HELP infiniband_switch_power_supply_status_info Infiniband switch power supply status
 		# TYPE infiniband_switch_power_supply_status_info gauge
-		infiniband_switch_power_supply_status_info{guid="0x506b4b03005c2740",psu="0",status="OK"} 1
-		infiniband_switch_power_supply_status_info{guid="0x506b4b03005c2740",psu="1",status="OK"} 1
-		infiniband_switch_power_supply_status_info{guid="0x7cfe9003009ce5b0",psu="0",status="OK"} 1
-		infiniband_switch_power_supply_status_info{guid="0x7cfe9003009ce5b0",psu="1",status="OK"} 1
+		infiniband_switch_power_supply_status_info{guid="0x506b4b03005c2740",psu="0",status="OK",switch="ib-i4l1s01"} 1
+		infiniband_switch_power_supply_status_info{guid="0x506b4b03005c2740",psu="1",status="OK",switch="ib-i4l1s01"} 1
+		infiniband_switch_power_supply_status_info{guid="0x7cfe9003009ce5b0",psu="0",status="OK",switch="ib-i1l1s01"} 1
+		infiniband_switch_power_supply_status_info{guid="0x7cfe9003009ce5b0",psu="1",status="OK",switch="ib-i1l1s01"} 1
 		# HELP infiniband_switch_power_supply_watts Infiniband switch power supply watts
 		# TYPE infiniband_switch_power_supply_watts gauge
-		infiniband_switch_power_supply_watts{guid="0x506b4b03005c2740",psu="0"} 154
-		infiniband_switch_power_supply_watts{guid="0x506b4b03005c2740",psu="1"} 134
-		infiniband_switch_power_supply_watts{guid="0x7cfe9003009ce5b0",psu="0"} 72
-		infiniband_switch_power_supply_watts{guid="0x7cfe9003009ce5b0",psu="1"} 71
+		infiniband_switch_power_supply_watts{guid="0x506b4b03005c2740",psu="0",switch="ib-i4l1s01"} 154
+		infiniband_switch_power_supply_watts{guid="0x506b4b03005c2740",psu="1",switch="ib-i4l1s01"} 134
+		infiniband_switch_power_supply_watts{guid="0x7cfe9003009ce5b0",psu="0",switch="ib-i1l1s01"} 72
+		infiniband_switch_power_supply_watts{guid="0x7cfe9003009ce5b0",psu="1",switch="ib-i1l1s01"} 71
 		# HELP infiniband_switch_temperature_celsius Infiniband switch temperature celsius
 		# TYPE infiniband_switch_temperature_celsius gauge
-		infiniband_switch_temperature_celsius{guid="0x506b4b03005c2740"} 53
-		infiniband_switch_temperature_celsius{guid="0x7cfe9003009ce5b0"} 45
+		infiniband_switch_temperature_celsius{guid="0x506b4b03005c2740",switch="ib-i4l1s01"} 53
+		infiniband_switch_temperature_celsius{guid="0x7cfe9003009ce5b0",switch="ib-i1l1s01"} 45
 		# HELP infiniband_switch_uptime_seconds Infiniband switch uptime in seconds
 		# TYPE infiniband_switch_uptime_seconds gauge
-		infiniband_switch_uptime_seconds{guid="0x506b4b03005c2740"} 8301347
-        infiniband_switch_uptime_seconds{guid="0x7cfe9003009ce5b0"} 13862333
+		infiniband_switch_uptime_seconds{guid="0x506b4b03005c2740",switch="ib-i4l1s01"} 8301347
+        infiniband_switch_uptime_seconds{guid="0x7cfe9003009ce5b0",switch="ib-i1l1s01"} 13862333
 	`
 	collector := NewIbswinfoCollector(&switchDevices, false, log.NewNopLogger())
 	gatherers := setupGatherer(collector)

--- a/collectors/switch.go
+++ b/collectors/switch.go
@@ -28,9 +28,10 @@ import (
 )
 
 var (
-	CollectSwitch       = kingpin.Flag("collector.switch", "Enable the switch collector").Default("true").Bool()
-	switchCollectBase   = kingpin.Flag("collector.switch.base-metrics", "Collect base metrics").Default("true").Bool()
-	switchCollectRcvErr = kingpin.Flag("collector.switch.rcv-err-details", "Collect Rcv Error Details").Default("false").Bool()
+	CollectSwitch          = kingpin.Flag("collector.switch", "Enable the switch collector").Default("true").Bool()
+	switchCollectBase      = kingpin.Flag("collector.switch.base-metrics", "Collect base metrics").Default("true").Bool()
+	switchCollectRcvErr    = kingpin.Flag("collector.switch.rcv-err-details", "Collect Rcv Error Details").Default("false").Bool()
+	switchCollectPortState = kingpin.Flag("collector.switch.port-state", "Report port link state (1=up, 0=down)").Default("false").Bool()
 )
 
 type SwitchCollector struct {
@@ -72,6 +73,7 @@ type SwitchCollector struct {
 	RawRate                      *prometheus.Desc
 	Uplink                       *prometheus.Desc
 	Info                         *prometheus.Desc
+	PortState                    *prometheus.Desc
 }
 
 type SwitchMetrics struct {
@@ -164,6 +166,8 @@ func NewSwitchCollector(devices *[]InfinibandDevice, runonce bool, logger log.Lo
 			"Infiniband switch uplink information", append(labels, []string{"uplink", "uplink_guid", "uplink_type", "uplink_port", "uplink_lid"}...), nil),
 		Info: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "info"),
 			"Infiniband switch information", []string{"guid", "switch", "lid"}, nil),
+		PortState: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "port_state"),
+			"Infiniband switch port link state (1=up, 0=down)", labels, nil),
 	}
 }
 
@@ -203,6 +207,7 @@ func (s *SwitchCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- s.RawRate
 	ch <- s.Uplink
 	ch <- s.Info
+	ch <- s.PortState
 }
 
 func (s *SwitchCollector) Collect(ch chan<- prometheus.Metric) {
@@ -314,6 +319,16 @@ func (s *SwitchCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(s.Duration, prometheus.GaugeValue, metric.rcvErrDuration, device.GUID, device.Name, fmt.Sprintf("%s-rcv-err", s.collector))
 			ch <- prometheus.MustNewConstMetric(s.Timeout, prometheus.GaugeValue, metric.rcvErrTimeout, device.GUID, device.Name, fmt.Sprintf("%s-rcv-err", s.collector))
 			ch <- prometheus.MustNewConstMetric(s.Error, prometheus.GaugeValue, metric.rcvErrError, device.GUID, device.Name, fmt.Sprintf("%s-rcv-err", s.collector))
+		}
+	}
+	if *switchCollectPortState {
+		for _, device := range *s.devices {
+			for port := range device.Uplinks {
+				ch <- prometheus.MustNewConstMetric(s.PortState, prometheus.GaugeValue, 1, device.GUID, device.Name, port)
+			}
+			for _, port := range device.DownPorts {
+				ch <- prometheus.MustNewConstMetric(s.PortState, prometheus.GaugeValue, 0, device.GUID, device.Name, port)
+			}
 		}
 	}
 	ch <- prometheus.MustNewConstMetric(collectErrors, prometheus.GaugeValue, errors, s.collector)

--- a/collectors/switch.go
+++ b/collectors/switch.go
@@ -84,7 +84,8 @@ type SwitchMetrics struct {
 }
 
 func NewSwitchCollector(devices *[]InfinibandDevice, runonce bool, logger log.Logger) *SwitchCollector {
-	labels := []string{"guid", "port"}
+	labels := []string{"guid", "switch", "port"}
+	collectLabels := []string{"guid", "switch", "collector"}
 	collector := "switch"
 	if runonce {
 		collector = "switch-runonce"
@@ -94,11 +95,11 @@ func NewSwitchCollector(devices *[]InfinibandDevice, runonce bool, logger log.Lo
 		logger:    log.With(logger, "collector", collector),
 		collector: collector,
 		Duration: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "collect_duration_seconds"),
-			"Duration of collection", []string{"guid", "collector"}, nil),
+			"Duration of collection", collectLabels, nil),
 		Error: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "collect_error"),
-			"Indicates if collect error", []string{"guid", "collector"}, nil),
+			"Indicates if collect error", collectLabels, nil),
 		Timeout: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "collect_timeout"),
-			"Indicates if collect timeout", []string{"guid", "collector"}, nil),
+			"Indicates if collect timeout", collectLabels, nil),
 		PortXmitData: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "port_transmit_data_bytes_total"),
 			"Infiniband switch port PortXmitData", labels, nil),
 		PortRcvData: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "port_receive_data_bytes_total"),
@@ -160,7 +161,7 @@ func NewSwitchCollector(devices *[]InfinibandDevice, runonce bool, logger log.Lo
 		RawRate: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "port_raw_rate_bytes_per_second"),
 			"Infiniband switch port raw rate", labels, nil),
 		Uplink: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "uplink_info"),
-			"Infiniband switch uplink information", append(labels, []string{"switch", "uplink", "uplink_guid", "uplink_type", "uplink_port", "uplink_lid"}...), nil),
+			"Infiniband switch uplink information", append(labels, []string{"uplink", "uplink_guid", "uplink_type", "uplink_port", "uplink_lid"}...), nil),
 		Info: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "info"),
 			"Infiniband switch information", []string{"guid", "switch", "lid"}, nil),
 	}
@@ -209,110 +210,110 @@ func (s *SwitchCollector) Collect(ch chan<- prometheus.Metric) {
 	counters, metrics, errors, timeouts := s.collect()
 	for _, c := range counters {
 		if !math.IsNaN(c.PortXmitData) {
-			ch <- prometheus.MustNewConstMetric(s.PortXmitData, prometheus.CounterValue, c.PortXmitData, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.PortXmitData, prometheus.CounterValue, c.PortXmitData, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.PortRcvData) {
-			ch <- prometheus.MustNewConstMetric(s.PortRcvData, prometheus.CounterValue, c.PortRcvData, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.PortRcvData, prometheus.CounterValue, c.PortRcvData, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.PortXmitPkts) {
-			ch <- prometheus.MustNewConstMetric(s.PortXmitPkts, prometheus.CounterValue, c.PortXmitPkts, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.PortXmitPkts, prometheus.CounterValue, c.PortXmitPkts, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.PortRcvPkts) {
-			ch <- prometheus.MustNewConstMetric(s.PortRcvPkts, prometheus.CounterValue, c.PortRcvPkts, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.PortRcvPkts, prometheus.CounterValue, c.PortRcvPkts, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.PortUnicastXmitPkts) {
-			ch <- prometheus.MustNewConstMetric(s.PortUnicastXmitPkts, prometheus.CounterValue, c.PortUnicastXmitPkts, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.PortUnicastXmitPkts, prometheus.CounterValue, c.PortUnicastXmitPkts, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.PortUnicastRcvPkts) {
-			ch <- prometheus.MustNewConstMetric(s.PortUnicastRcvPkts, prometheus.CounterValue, c.PortUnicastRcvPkts, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.PortUnicastRcvPkts, prometheus.CounterValue, c.PortUnicastRcvPkts, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.PortMulticastXmitPkts) {
-			ch <- prometheus.MustNewConstMetric(s.PortMulticastXmitPkts, prometheus.CounterValue, c.PortMulticastXmitPkts, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.PortMulticastXmitPkts, prometheus.CounterValue, c.PortMulticastXmitPkts, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.PortMulticastRcvPkts) {
-			ch <- prometheus.MustNewConstMetric(s.PortMulticastRcvPkts, prometheus.CounterValue, c.PortMulticastRcvPkts, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.PortMulticastRcvPkts, prometheus.CounterValue, c.PortMulticastRcvPkts, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.SymbolErrorCounter) {
-			ch <- prometheus.MustNewConstMetric(s.SymbolErrorCounter, prometheus.CounterValue, c.SymbolErrorCounter, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.SymbolErrorCounter, prometheus.CounterValue, c.SymbolErrorCounter, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.LinkErrorRecoveryCounter) {
-			ch <- prometheus.MustNewConstMetric(s.LinkErrorRecoveryCounter, prometheus.CounterValue, c.LinkErrorRecoveryCounter, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.LinkErrorRecoveryCounter, prometheus.CounterValue, c.LinkErrorRecoveryCounter, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.LinkDownedCounter) {
-			ch <- prometheus.MustNewConstMetric(s.LinkDownedCounter, prometheus.CounterValue, c.LinkDownedCounter, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.LinkDownedCounter, prometheus.CounterValue, c.LinkDownedCounter, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.PortRcvErrors) {
-			ch <- prometheus.MustNewConstMetric(s.PortRcvErrors, prometheus.CounterValue, c.PortRcvErrors, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.PortRcvErrors, prometheus.CounterValue, c.PortRcvErrors, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.PortRcvRemotePhysicalErrors) {
-			ch <- prometheus.MustNewConstMetric(s.PortRcvRemotePhysicalErrors, prometheus.CounterValue, c.PortRcvRemotePhysicalErrors, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.PortRcvRemotePhysicalErrors, prometheus.CounterValue, c.PortRcvRemotePhysicalErrors, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.PortRcvSwitchRelayErrors) {
-			ch <- prometheus.MustNewConstMetric(s.PortRcvSwitchRelayErrors, prometheus.CounterValue, c.PortRcvSwitchRelayErrors, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.PortRcvSwitchRelayErrors, prometheus.CounterValue, c.PortRcvSwitchRelayErrors, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.PortXmitDiscards) {
-			ch <- prometheus.MustNewConstMetric(s.PortXmitDiscards, prometheus.CounterValue, c.PortXmitDiscards, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.PortXmitDiscards, prometheus.CounterValue, c.PortXmitDiscards, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.PortXmitConstraintErrors) {
-			ch <- prometheus.MustNewConstMetric(s.PortXmitConstraintErrors, prometheus.CounterValue, c.PortXmitConstraintErrors, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.PortXmitConstraintErrors, prometheus.CounterValue, c.PortXmitConstraintErrors, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.PortRcvConstraintErrors) {
-			ch <- prometheus.MustNewConstMetric(s.PortRcvConstraintErrors, prometheus.CounterValue, c.PortRcvConstraintErrors, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.PortRcvConstraintErrors, prometheus.CounterValue, c.PortRcvConstraintErrors, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.LocalLinkIntegrityErrors) {
-			ch <- prometheus.MustNewConstMetric(s.LocalLinkIntegrityErrors, prometheus.CounterValue, c.LocalLinkIntegrityErrors, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.LocalLinkIntegrityErrors, prometheus.CounterValue, c.LocalLinkIntegrityErrors, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.ExcessiveBufferOverrunErrors) {
-			ch <- prometheus.MustNewConstMetric(s.ExcessiveBufferOverrunErrors, prometheus.CounterValue, c.ExcessiveBufferOverrunErrors, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.ExcessiveBufferOverrunErrors, prometheus.CounterValue, c.ExcessiveBufferOverrunErrors, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.VL15Dropped) {
-			ch <- prometheus.MustNewConstMetric(s.VL15Dropped, prometheus.CounterValue, c.VL15Dropped, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.VL15Dropped, prometheus.CounterValue, c.VL15Dropped, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.PortXmitWait) {
-			ch <- prometheus.MustNewConstMetric(s.PortXmitWait, prometheus.CounterValue, c.PortXmitWait, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.PortXmitWait, prometheus.CounterValue, c.PortXmitWait, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.QP1Dropped) {
-			ch <- prometheus.MustNewConstMetric(s.QP1Dropped, prometheus.CounterValue, c.QP1Dropped, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.QP1Dropped, prometheus.CounterValue, c.QP1Dropped, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.PortLocalPhysicalErrors) {
-			ch <- prometheus.MustNewConstMetric(s.PortLocalPhysicalErrors, prometheus.CounterValue, c.PortLocalPhysicalErrors, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.PortLocalPhysicalErrors, prometheus.CounterValue, c.PortLocalPhysicalErrors, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.PortMalformedPktErrors) {
-			ch <- prometheus.MustNewConstMetric(s.PortMalformedPktErrors, prometheus.CounterValue, c.PortMalformedPktErrors, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.PortMalformedPktErrors, prometheus.CounterValue, c.PortMalformedPktErrors, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.PortBufferOverrunErrors) {
-			ch <- prometheus.MustNewConstMetric(s.PortBufferOverrunErrors, prometheus.CounterValue, c.PortBufferOverrunErrors, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.PortBufferOverrunErrors, prometheus.CounterValue, c.PortBufferOverrunErrors, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.PortDLIDMappingErrors) {
-			ch <- prometheus.MustNewConstMetric(s.PortDLIDMappingErrors, prometheus.CounterValue, c.PortDLIDMappingErrors, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.PortDLIDMappingErrors, prometheus.CounterValue, c.PortDLIDMappingErrors, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.PortVLMappingErrors) {
-			ch <- prometheus.MustNewConstMetric(s.PortVLMappingErrors, prometheus.CounterValue, c.PortVLMappingErrors, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.PortVLMappingErrors, prometheus.CounterValue, c.PortVLMappingErrors, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 		if !math.IsNaN(c.PortLoopingErrors) {
-			ch <- prometheus.MustNewConstMetric(s.PortLoopingErrors, prometheus.CounterValue, c.PortLoopingErrors, c.device.GUID, c.PortSelect)
+			ch <- prometheus.MustNewConstMetric(s.PortLoopingErrors, prometheus.CounterValue, c.PortLoopingErrors, c.device.GUID, c.device.Name, c.PortSelect)
 		}
 	}
 	if *switchCollectBase {
 		for _, device := range *s.devices {
 			metric := metrics[device.GUID]
 			ch <- prometheus.MustNewConstMetric(s.Info, prometheus.GaugeValue, 1, device.GUID, device.Name, device.LID)
-			ch <- prometheus.MustNewConstMetric(s.Duration, prometheus.GaugeValue, metric.duration, device.GUID, s.collector)
-			ch <- prometheus.MustNewConstMetric(s.Timeout, prometheus.GaugeValue, metric.timeout, device.GUID, s.collector)
-			ch <- prometheus.MustNewConstMetric(s.Error, prometheus.GaugeValue, metric.error, device.GUID, s.collector)
+			ch <- prometheus.MustNewConstMetric(s.Duration, prometheus.GaugeValue, metric.duration, device.GUID, device.Name, s.collector)
+			ch <- prometheus.MustNewConstMetric(s.Timeout, prometheus.GaugeValue, metric.timeout, device.GUID, device.Name, s.collector)
+			ch <- prometheus.MustNewConstMetric(s.Error, prometheus.GaugeValue, metric.error, device.GUID, device.Name, s.collector)
 			for port, uplink := range device.Uplinks {
-				ch <- prometheus.MustNewConstMetric(s.Rate, prometheus.GaugeValue, uplink.Rate, device.GUID, port)
-				ch <- prometheus.MustNewConstMetric(s.RawRate, prometheus.GaugeValue, uplink.RawRate, device.GUID, port)
-				ch <- prometheus.MustNewConstMetric(s.Uplink, prometheus.GaugeValue, 1, device.GUID, port, device.Name, uplink.Name, uplink.GUID, uplink.Type, uplink.PortNumber, uplink.LID)
+				ch <- prometheus.MustNewConstMetric(s.Rate, prometheus.GaugeValue, uplink.Rate, device.GUID, device.Name, port)
+				ch <- prometheus.MustNewConstMetric(s.RawRate, prometheus.GaugeValue, uplink.RawRate, device.GUID, device.Name, port)
+				ch <- prometheus.MustNewConstMetric(s.Uplink, prometheus.GaugeValue, 1, device.GUID, device.Name, port, uplink.Name, uplink.GUID, uplink.Type, uplink.PortNumber, uplink.LID)
 			}
 		}
 	}
 	if *switchCollectRcvErr {
 		for _, device := range *s.devices {
 			metric := metrics[device.GUID]
-			ch <- prometheus.MustNewConstMetric(s.Duration, prometheus.GaugeValue, metric.rcvErrDuration, device.GUID, fmt.Sprintf("%s-rcv-err", s.collector))
-			ch <- prometheus.MustNewConstMetric(s.Timeout, prometheus.GaugeValue, metric.rcvErrTimeout, device.GUID, fmt.Sprintf("%s-rcv-err", s.collector))
-			ch <- prometheus.MustNewConstMetric(s.Error, prometheus.GaugeValue, metric.rcvErrError, device.GUID, fmt.Sprintf("%s-rcv-err", s.collector))
+			ch <- prometheus.MustNewConstMetric(s.Duration, prometheus.GaugeValue, metric.rcvErrDuration, device.GUID, device.Name, fmt.Sprintf("%s-rcv-err", s.collector))
+			ch <- prometheus.MustNewConstMetric(s.Timeout, prometheus.GaugeValue, metric.rcvErrTimeout, device.GUID, device.Name, fmt.Sprintf("%s-rcv-err", s.collector))
+			ch <- prometheus.MustNewConstMetric(s.Error, prometheus.GaugeValue, metric.rcvErrError, device.GUID, device.Name, fmt.Sprintf("%s-rcv-err", s.collector))
 		}
 	}
 	ch <- prometheus.MustNewConstMetric(collectErrors, prometheus.GaugeValue, errors, s.collector)

--- a/collectors/switch_test.go
+++ b/collectors/switch_test.go
@@ -550,3 +550,41 @@ func TestSwitchCollectorTimeout(t *testing.T) {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
 }
+
+func TestSwitchCollectorPortState(t *testing.T) {
+	if _, err := kingpin.CommandLine.Parse([]string{"--collector.switch.port-state"}); err != nil {
+		t.Fatal(err)
+	}
+	SetPerfqueryExecs(t, false, false)
+	expected := `
+		# HELP infiniband_switch_port_state Infiniband switch port link state (1=up, 0=down)
+		# TYPE infiniband_switch_port_state gauge
+		infiniband_switch_port_state{guid="0x506b4b03005c2740",port="35",switch="ib-i4l1s01"} 1
+		infiniband_switch_port_state{guid="0x506b4b03005c2740",port="37",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_state{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 1
+		infiniband_switch_port_state{guid="0x7cfe9003009ce5b0",port="10",switch="ib-i1l1s01"} 1
+		infiniband_switch_port_state{guid="0x7cfe9003009ce5b0",port="11",switch="ib-i1l1s01"} 1
+	`
+	collector := NewSwitchCollector(&switchDevices, false, log.NewNopLogger())
+	gatherers := setupGatherer(collector)
+	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
+		"infiniband_switch_port_state"); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+}
+
+func TestSwitchCollectorPortStateDisabled(t *testing.T) {
+	if _, err := kingpin.CommandLine.Parse([]string{}); err != nil {
+		t.Fatal(err)
+	}
+	SetPerfqueryExecs(t, false, false)
+	collector := NewSwitchCollector(&switchDevices, false, log.NewNopLogger())
+	gatherers := setupGatherer(collector)
+	metrics, err := testutil.GatherAndCount(gatherers, "infiniband_switch_port_state")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if metrics != 0 {
+		t.Errorf("Expected 0 port_state metrics when disabled, got %d", metrics)
+	}
+}

--- a/collectors/switch_test.go
+++ b/collectors/switch_test.go
@@ -40,126 +40,126 @@ func TestSwitchCollector(t *testing.T) {
 		infiniband_switch_info{guid="0x7cfe9003009ce5b0",lid="1719",switch="ib-i1l1s01"} 1
 		# HELP infiniband_switch_port_excessive_buffer_overrun_errors_total Infiniband switch port ExcessiveBufferOverrunErrors
 		# TYPE infiniband_switch_port_excessive_buffer_overrun_errors_total counter
-		infiniband_switch_port_excessive_buffer_overrun_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_excessive_buffer_overrun_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_excessive_buffer_overrun_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_excessive_buffer_overrun_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_excessive_buffer_overrun_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_excessive_buffer_overrun_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_link_downed_total Infiniband switch port LinkDownedCounter
 		# TYPE infiniband_switch_port_link_downed_total counter
-		infiniband_switch_port_link_downed_total{guid="0x506b4b03005c2740",port="1"} 1
-		infiniband_switch_port_link_downed_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_link_downed_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_link_downed_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 1
+		infiniband_switch_port_link_downed_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_link_downed_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_link_error_recovery_total Infiniband switch port LinkErrorRecoveryCounter
 		# TYPE infiniband_switch_port_link_error_recovery_total counter
-		infiniband_switch_port_link_error_recovery_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_link_error_recovery_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_link_error_recovery_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_link_error_recovery_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_link_error_recovery_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_link_error_recovery_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_local_link_integrity_errors_total Infiniband switch port LocalLinkIntegrityErrors
 		# TYPE infiniband_switch_port_local_link_integrity_errors_total counter
-		infiniband_switch_port_local_link_integrity_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_local_link_integrity_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_local_link_integrity_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_local_link_integrity_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_local_link_integrity_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_local_link_integrity_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_multicast_receive_packets_total Infiniband switch port PortMulticastRcvPkts
 		# TYPE infiniband_switch_port_multicast_receive_packets_total counter
-		infiniband_switch_port_multicast_receive_packets_total{guid="0x506b4b03005c2740",port="1"} 6694940
-		infiniband_switch_port_multicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="1"} 5584846741
-		infiniband_switch_port_multicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_multicast_receive_packets_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 6694940
+		infiniband_switch_port_multicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 5584846741
+		infiniband_switch_port_multicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_multicast_transmit_packets_total Infiniband switch port PortMulticastXmitPkts
 		# TYPE infiniband_switch_port_multicast_transmit_packets_total counter
-		infiniband_switch_port_multicast_transmit_packets_total{guid="0x506b4b03005c2740",port="1"} 5623645694
-		infiniband_switch_port_multicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="1"} 25038914
-		infiniband_switch_port_multicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_multicast_transmit_packets_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 5623645694
+		infiniband_switch_port_multicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 25038914
+		infiniband_switch_port_multicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_qp1_dropped_total Infiniband switch port QP1Dropped
 		# TYPE infiniband_switch_port_qp1_dropped_total counter
-		infiniband_switch_port_qp1_dropped_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_qp1_dropped_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_qp1_dropped_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_qp1_dropped_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_qp1_dropped_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_qp1_dropped_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_rate_bytes_per_second Infiniband switch port rate
 		# TYPE infiniband_switch_port_rate_bytes_per_second gauge
-		infiniband_switch_port_rate_bytes_per_second{guid="0x506b4b03005c2740",port="35"} 1.25e+10
-		infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="10"} 1.25e+10
-		infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="11"} 1.25e+10
-		infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="1"} 1.25e+10
+		infiniband_switch_port_rate_bytes_per_second{guid="0x506b4b03005c2740",port="35",switch="ib-i4l1s01"} 1.25e+10
+		infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="10",switch="ib-i1l1s01"} 1.25e+10
+		infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="11",switch="ib-i1l1s01"} 1.25e+10
+		infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 1.25e+10
 		# HELP infiniband_switch_port_raw_rate_bytes_per_second Infiniband switch port raw rate
 		# TYPE infiniband_switch_port_raw_rate_bytes_per_second gauge
-		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x506b4b03005c2740",port="35"} 1.2890625e+10
-		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="10"} 1.2890625e+10
-		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="11"} 1.2890625e+10
-		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="1"} 1.2890625e+10
+		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x506b4b03005c2740",port="35",switch="ib-i4l1s01"} 1.2890625e+10
+		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="10",switch="ib-i1l1s01"} 1.2890625e+10
+		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="11",switch="ib-i1l1s01"} 1.2890625e+10
+		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 1.2890625e+10
 		# HELP infiniband_switch_port_receive_constraint_errors_total Infiniband switch port PortRcvConstraintErrors
 		# TYPE infiniband_switch_port_receive_constraint_errors_total counter
-		infiniband_switch_port_receive_constraint_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_receive_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_receive_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_receive_constraint_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_receive_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_receive_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_receive_data_bytes_total Infiniband switch port PortRcvData
 		# TYPE infiniband_switch_port_receive_data_bytes_total counter
-		infiniband_switch_port_receive_data_bytes_total{guid="0x506b4b03005c2740",port="1"} 715049367846516
-		infiniband_switch_port_receive_data_bytes_total{guid="0x7cfe9003009ce5b0",port="1"} 49116115103004
-		infiniband_switch_port_receive_data_bytes_total{guid="0x7cfe9003009ce5b0",port="2"} 156315219973512
+		infiniband_switch_port_receive_data_bytes_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 715049367846516
+		infiniband_switch_port_receive_data_bytes_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 49116115103004
+		infiniband_switch_port_receive_data_bytes_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 156315219973512
 		# HELP infiniband_switch_port_receive_errors_total Infiniband switch port PortRcvErrors
 		# TYPE infiniband_switch_port_receive_errors_total counter
-		infiniband_switch_port_receive_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_receive_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_receive_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_receive_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_receive_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_receive_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_receive_packets_total Infiniband switch port PortRcvPkts
 		# TYPE infiniband_switch_port_receive_packets_total counter
-		infiniband_switch_port_receive_packets_total{guid="0x506b4b03005c2740",port="1"} 387654829341
-		infiniband_switch_port_receive_packets_total{guid="0x7cfe9003009ce5b0",port="1"} 32262508468
-		infiniband_switch_port_receive_packets_total{guid="0x7cfe9003009ce5b0",port="2"} 93660802641
+		infiniband_switch_port_receive_packets_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 387654829341
+		infiniband_switch_port_receive_packets_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 32262508468
+		infiniband_switch_port_receive_packets_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 93660802641
 		# HELP infiniband_switch_port_receive_remote_physical_errors_total Infiniband switch port PortRcvRemotePhysicalErrors
 		# TYPE infiniband_switch_port_receive_remote_physical_errors_total counter
-		infiniband_switch_port_receive_remote_physical_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_receive_remote_physical_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_receive_remote_physical_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_receive_remote_physical_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_receive_remote_physical_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_receive_remote_physical_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_receive_switch_relay_errors_total Infiniband switch port PortRcvSwitchRelayErrors
 		# TYPE infiniband_switch_port_receive_switch_relay_errors_total counter
-		infiniband_switch_port_receive_switch_relay_errors_total{guid="0x506b4b03005c2740",port="1"} 7
-		infiniband_switch_port_receive_switch_relay_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_receive_switch_relay_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_receive_switch_relay_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 7
+		infiniband_switch_port_receive_switch_relay_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_receive_switch_relay_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_symbol_error_total Infiniband switch port SymbolErrorCounter
 		# TYPE infiniband_switch_port_symbol_error_total counter
-		infiniband_switch_port_symbol_error_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_symbol_error_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_symbol_error_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_symbol_error_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_symbol_error_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_symbol_error_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_transmit_constraint_errors_total Infiniband switch port PortXmitConstraintErrors
 		# TYPE infiniband_switch_port_transmit_constraint_errors_total counter
-		infiniband_switch_port_transmit_constraint_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_transmit_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_transmit_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_transmit_constraint_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_transmit_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_transmit_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_transmit_data_bytes_total Infiniband switch port PortXmitData
 		# TYPE infiniband_switch_port_transmit_data_bytes_total counter
-		infiniband_switch_port_transmit_data_bytes_total{guid="0x506b4b03005c2740",port="1"} 715166628708940
-		infiniband_switch_port_transmit_data_bytes_total{guid="0x7cfe9003009ce5b0",port="1"} 145192107443712
-		infiniband_switch_port_transmit_data_bytes_total{guid="0x7cfe9003009ce5b0",port="2"} 104026280056104
+		infiniband_switch_port_transmit_data_bytes_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 715166628708940
+		infiniband_switch_port_transmit_data_bytes_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 145192107443712
+		infiniband_switch_port_transmit_data_bytes_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 104026280056104
 		# HELP infiniband_switch_port_transmit_discards_total Infiniband switch port PortXmitDiscards
 		# TYPE infiniband_switch_port_transmit_discards_total counter
-		infiniband_switch_port_transmit_discards_total{guid="0x506b4b03005c2740",port="1"} 20046
-		infiniband_switch_port_transmit_discards_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_transmit_discards_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_transmit_discards_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 20046
+		infiniband_switch_port_transmit_discards_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_transmit_discards_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_transmit_packets_total Infiniband switch port PortXmitPkts
 		# TYPE infiniband_switch_port_transmit_packets_total counter
-		infiniband_switch_port_transmit_packets_total{guid="0x506b4b03005c2740",port="1"} 393094651266
-		infiniband_switch_port_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="1"} 101733204203
-		infiniband_switch_port_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="2"} 122978948297
+		infiniband_switch_port_transmit_packets_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 393094651266
+		infiniband_switch_port_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 101733204203
+		infiniband_switch_port_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 122978948297
 		# HELP infiniband_switch_port_transmit_wait_total Infiniband switch port PortXmitWait
 		# TYPE infiniband_switch_port_transmit_wait_total counter
-		infiniband_switch_port_transmit_wait_total{guid="0x506b4b03005c2740",port="1"} 41864608
-		infiniband_switch_port_transmit_wait_total{guid="0x7cfe9003009ce5b0",port="1"} 22730501
-		infiniband_switch_port_transmit_wait_total{guid="0x7cfe9003009ce5b0",port="2"} 36510964
+		infiniband_switch_port_transmit_wait_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 41864608
+		infiniband_switch_port_transmit_wait_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 22730501
+		infiniband_switch_port_transmit_wait_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 36510964
 		# HELP infiniband_switch_port_unicast_receive_packets_total Infiniband switch port PortUnicastRcvPkts
 		# TYPE infiniband_switch_port_unicast_receive_packets_total counter
-		infiniband_switch_port_unicast_receive_packets_total{guid="0x506b4b03005c2740",port="1"} 387648134400
-		infiniband_switch_port_unicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="1"} 26677661727
-		infiniband_switch_port_unicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="2"} 93660802641
+		infiniband_switch_port_unicast_receive_packets_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 387648134400
+		infiniband_switch_port_unicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 26677661727
+		infiniband_switch_port_unicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 93660802641
 		# HELP infiniband_switch_port_unicast_transmit_packets_total Infiniband switch port PortUnicastXmitPkts
 		# TYPE infiniband_switch_port_unicast_transmit_packets_total counter
-		infiniband_switch_port_unicast_transmit_packets_total{guid="0x506b4b03005c2740",port="1"} 387471005571
-		infiniband_switch_port_unicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="1"} 101708165289
-		infiniband_switch_port_unicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="2"} 122978948297
+		infiniband_switch_port_unicast_transmit_packets_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 387471005571
+		infiniband_switch_port_unicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 101708165289
+		infiniband_switch_port_unicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 122978948297
 		# HELP infiniband_switch_port_vl15_dropped_total Infiniband switch port VL15Dropped
 		# TYPE infiniband_switch_port_vl15_dropped_total counter
-		infiniband_switch_port_vl15_dropped_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_vl15_dropped_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_vl15_dropped_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_vl15_dropped_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_vl15_dropped_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_vl15_dropped_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_uplink_info Infiniband switch uplink information
 		# TYPE infiniband_switch_uplink_info gauge
 		infiniband_switch_uplink_info{guid="0x506b4b03005c2740",port="35",switch="ib-i4l1s01",uplink="p0001 HCA-1",uplink_guid="0x506b4b0300cc02a6",uplink_lid="1432",uplink_port="1",uplink_type="CA"} 1
@@ -211,156 +211,156 @@ func TestSwitchCollectorFull(t *testing.T) {
 		infiniband_switch_info{guid="0x7cfe9003009ce5b0",lid="1719",switch="ib-i1l1s01"} 1
 		# HELP infiniband_switch_port_buffer_overrun_errors_total Infiniband switch port PortBufferOverrunErrors
 		# TYPE infiniband_switch_port_buffer_overrun_errors_total counter
-		infiniband_switch_port_buffer_overrun_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_buffer_overrun_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_buffer_overrun_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_buffer_overrun_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_buffer_overrun_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_buffer_overrun_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_dli_mapping_errors_total Infiniband switch port PortDLIDMappingErrors
 		# TYPE infiniband_switch_port_dli_mapping_errors_total counter
-		infiniband_switch_port_dli_mapping_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_dli_mapping_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_dli_mapping_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_dli_mapping_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_dli_mapping_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_dli_mapping_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_excessive_buffer_overrun_errors_total Infiniband switch port ExcessiveBufferOverrunErrors
 		# TYPE infiniband_switch_port_excessive_buffer_overrun_errors_total counter
-		infiniband_switch_port_excessive_buffer_overrun_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_excessive_buffer_overrun_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_excessive_buffer_overrun_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_excessive_buffer_overrun_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_excessive_buffer_overrun_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_excessive_buffer_overrun_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_link_downed_total Infiniband switch port LinkDownedCounter
 		# TYPE infiniband_switch_port_link_downed_total counter
-		infiniband_switch_port_link_downed_total{guid="0x506b4b03005c2740",port="1"} 1
-		infiniband_switch_port_link_downed_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_link_downed_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_link_downed_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 1
+		infiniband_switch_port_link_downed_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_link_downed_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_link_error_recovery_total Infiniband switch port LinkErrorRecoveryCounter
 		# TYPE infiniband_switch_port_link_error_recovery_total counter
-		infiniband_switch_port_link_error_recovery_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_link_error_recovery_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_link_error_recovery_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_link_error_recovery_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_link_error_recovery_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_link_error_recovery_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_local_link_integrity_errors_total Infiniband switch port LocalLinkIntegrityErrors
 		# TYPE infiniband_switch_port_local_link_integrity_errors_total counter
-		infiniband_switch_port_local_link_integrity_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_local_link_integrity_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_local_link_integrity_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_local_link_integrity_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_local_link_integrity_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_local_link_integrity_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_local_physical_errors_total Infiniband switch port PortLocalPhysicalErrors
 		# TYPE infiniband_switch_port_local_physical_errors_total counter
-		infiniband_switch_port_local_physical_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_local_physical_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_local_physical_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_local_physical_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_local_physical_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_local_physical_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_looping_errors_total Infiniband switch port PortLoopingErrors
 		# TYPE infiniband_switch_port_looping_errors_total counter
-		infiniband_switch_port_looping_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_looping_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_looping_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_looping_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_looping_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_looping_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_malformed_packet_errors_total Infiniband switch port PortMalformedPktErrors
 		# TYPE infiniband_switch_port_malformed_packet_errors_total counter
-		infiniband_switch_port_malformed_packet_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_malformed_packet_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_malformed_packet_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_malformed_packet_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_malformed_packet_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_malformed_packet_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_multicast_receive_packets_total Infiniband switch port PortMulticastRcvPkts
 		# TYPE infiniband_switch_port_multicast_receive_packets_total counter
-		infiniband_switch_port_multicast_receive_packets_total{guid="0x506b4b03005c2740",port="1"} 6694940
-		infiniband_switch_port_multicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="1"} 5584846741
-		infiniband_switch_port_multicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_multicast_receive_packets_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 6694940
+		infiniband_switch_port_multicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 5584846741
+		infiniband_switch_port_multicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_multicast_transmit_packets_total Infiniband switch port PortMulticastXmitPkts
 		# TYPE infiniband_switch_port_multicast_transmit_packets_total counter
-		infiniband_switch_port_multicast_transmit_packets_total{guid="0x506b4b03005c2740",port="1"} 5623645694
-		infiniband_switch_port_multicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="1"} 25038914
-		infiniband_switch_port_multicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_multicast_transmit_packets_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 5623645694
+		infiniband_switch_port_multicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 25038914
+		infiniband_switch_port_multicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_qp1_dropped_total Infiniband switch port QP1Dropped
 		# TYPE infiniband_switch_port_qp1_dropped_total counter
-		infiniband_switch_port_qp1_dropped_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_qp1_dropped_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_qp1_dropped_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_qp1_dropped_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_qp1_dropped_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_qp1_dropped_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_rate_bytes_per_second Infiniband switch port rate
 		# TYPE infiniband_switch_port_rate_bytes_per_second gauge
-		infiniband_switch_port_rate_bytes_per_second{guid="0x506b4b03005c2740",port="35"} 1.25e+10
-		infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="10"} 1.25e+10
-		infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="11"} 1.25e+10
-		infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="1"} 1.25e+10
+		infiniband_switch_port_rate_bytes_per_second{guid="0x506b4b03005c2740",port="35",switch="ib-i4l1s01"} 1.25e+10
+		infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="10",switch="ib-i1l1s01"} 1.25e+10
+		infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="11",switch="ib-i1l1s01"} 1.25e+10
+		infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 1.25e+10
 		# HELP infiniband_switch_port_raw_rate_bytes_per_second Infiniband switch port raw rate
 		# TYPE infiniband_switch_port_raw_rate_bytes_per_second gauge
-		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x506b4b03005c2740",port="35"} 1.2890625e+10
-		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="10"} 1.2890625e+10
-		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="11"} 1.2890625e+10
-		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="1"} 1.2890625e+10
+		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x506b4b03005c2740",port="35",switch="ib-i4l1s01"} 1.2890625e+10
+		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="10",switch="ib-i1l1s01"} 1.2890625e+10
+		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="11",switch="ib-i1l1s01"} 1.2890625e+10
+		infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 1.2890625e+10
 		# HELP infiniband_switch_port_receive_constraint_errors_total Infiniband switch port PortRcvConstraintErrors
 		# TYPE infiniband_switch_port_receive_constraint_errors_total counter
-		infiniband_switch_port_receive_constraint_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_receive_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_receive_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_receive_constraint_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_receive_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_receive_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_receive_data_bytes_total Infiniband switch port PortRcvData
 		# TYPE infiniband_switch_port_receive_data_bytes_total counter
-		infiniband_switch_port_receive_data_bytes_total{guid="0x506b4b03005c2740",port="1"} 715049367846516
-		infiniband_switch_port_receive_data_bytes_total{guid="0x7cfe9003009ce5b0",port="1"} 49116115103004
-		infiniband_switch_port_receive_data_bytes_total{guid="0x7cfe9003009ce5b0",port="2"} 156315219973512
+		infiniband_switch_port_receive_data_bytes_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 715049367846516
+		infiniband_switch_port_receive_data_bytes_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 49116115103004
+		infiniband_switch_port_receive_data_bytes_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 156315219973512
 		# HELP infiniband_switch_port_receive_errors_total Infiniband switch port PortRcvErrors
 		# TYPE infiniband_switch_port_receive_errors_total counter
-		infiniband_switch_port_receive_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_receive_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_receive_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_receive_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_receive_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_receive_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_receive_packets_total Infiniband switch port PortRcvPkts
 		# TYPE infiniband_switch_port_receive_packets_total counter
-		infiniband_switch_port_receive_packets_total{guid="0x506b4b03005c2740",port="1"} 387654829341
-		infiniband_switch_port_receive_packets_total{guid="0x7cfe9003009ce5b0",port="1"} 32262508468
-		infiniband_switch_port_receive_packets_total{guid="0x7cfe9003009ce5b0",port="2"} 93660802641
+		infiniband_switch_port_receive_packets_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 387654829341
+		infiniband_switch_port_receive_packets_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 32262508468
+		infiniband_switch_port_receive_packets_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 93660802641
 		# HELP infiniband_switch_port_receive_remote_physical_errors_total Infiniband switch port PortRcvRemotePhysicalErrors
 		# TYPE infiniband_switch_port_receive_remote_physical_errors_total counter
-		infiniband_switch_port_receive_remote_physical_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_receive_remote_physical_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_receive_remote_physical_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_receive_remote_physical_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_receive_remote_physical_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_receive_remote_physical_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_receive_switch_relay_errors_total Infiniband switch port PortRcvSwitchRelayErrors
 		# TYPE infiniband_switch_port_receive_switch_relay_errors_total counter
-		infiniband_switch_port_receive_switch_relay_errors_total{guid="0x506b4b03005c2740",port="1"} 7
-		infiniband_switch_port_receive_switch_relay_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_receive_switch_relay_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_receive_switch_relay_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 7
+		infiniband_switch_port_receive_switch_relay_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_receive_switch_relay_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_symbol_error_total Infiniband switch port SymbolErrorCounter
 		# TYPE infiniband_switch_port_symbol_error_total counter
-		infiniband_switch_port_symbol_error_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_symbol_error_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_symbol_error_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_symbol_error_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_symbol_error_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_symbol_error_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_transmit_constraint_errors_total Infiniband switch port PortXmitConstraintErrors
 		# TYPE infiniband_switch_port_transmit_constraint_errors_total counter
-		infiniband_switch_port_transmit_constraint_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_transmit_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_transmit_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_transmit_constraint_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_transmit_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_transmit_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_transmit_data_bytes_total Infiniband switch port PortXmitData
 		# TYPE infiniband_switch_port_transmit_data_bytes_total counter
-		infiniband_switch_port_transmit_data_bytes_total{guid="0x506b4b03005c2740",port="1"} 715166628708940
-		infiniband_switch_port_transmit_data_bytes_total{guid="0x7cfe9003009ce5b0",port="1"} 145192107443712
-		infiniband_switch_port_transmit_data_bytes_total{guid="0x7cfe9003009ce5b0",port="2"} 104026280056104
+		infiniband_switch_port_transmit_data_bytes_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 715166628708940
+		infiniband_switch_port_transmit_data_bytes_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 145192107443712
+		infiniband_switch_port_transmit_data_bytes_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 104026280056104
 		# HELP infiniband_switch_port_transmit_discards_total Infiniband switch port PortXmitDiscards
 		# TYPE infiniband_switch_port_transmit_discards_total counter
-		infiniband_switch_port_transmit_discards_total{guid="0x506b4b03005c2740",port="1"} 20046
-		infiniband_switch_port_transmit_discards_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_transmit_discards_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_transmit_discards_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 20046
+		infiniband_switch_port_transmit_discards_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_transmit_discards_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_transmit_packets_total Infiniband switch port PortXmitPkts
 		# TYPE infiniband_switch_port_transmit_packets_total counter
-		infiniband_switch_port_transmit_packets_total{guid="0x506b4b03005c2740",port="1"} 393094651266
-		infiniband_switch_port_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="1"} 101733204203
-		infiniband_switch_port_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="2"} 122978948297
+		infiniband_switch_port_transmit_packets_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 393094651266
+		infiniband_switch_port_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 101733204203
+		infiniband_switch_port_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 122978948297
 		# HELP infiniband_switch_port_transmit_wait_total Infiniband switch port PortXmitWait
 		# TYPE infiniband_switch_port_transmit_wait_total counter
-		infiniband_switch_port_transmit_wait_total{guid="0x506b4b03005c2740",port="1"} 41864608
-		infiniband_switch_port_transmit_wait_total{guid="0x7cfe9003009ce5b0",port="1"} 22730501
-		infiniband_switch_port_transmit_wait_total{guid="0x7cfe9003009ce5b0",port="2"} 36510964
+		infiniband_switch_port_transmit_wait_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 41864608
+		infiniband_switch_port_transmit_wait_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 22730501
+		infiniband_switch_port_transmit_wait_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 36510964
 		# HELP infiniband_switch_port_unicast_receive_packets_total Infiniband switch port PortUnicastRcvPkts
 		# TYPE infiniband_switch_port_unicast_receive_packets_total counter
-		infiniband_switch_port_unicast_receive_packets_total{guid="0x506b4b03005c2740",port="1"} 387648134400
-		infiniband_switch_port_unicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="1"} 26677661727
-		infiniband_switch_port_unicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="2"} 93660802641
+		infiniband_switch_port_unicast_receive_packets_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 387648134400
+		infiniband_switch_port_unicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 26677661727
+		infiniband_switch_port_unicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 93660802641
 		# HELP infiniband_switch_port_unicast_transmit_packets_total Infiniband switch port PortUnicastXmitPkts
 		# TYPE infiniband_switch_port_unicast_transmit_packets_total counter
-		infiniband_switch_port_unicast_transmit_packets_total{guid="0x506b4b03005c2740",port="1"} 387471005571
-		infiniband_switch_port_unicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="1"} 101708165289
-		infiniband_switch_port_unicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="2"} 122978948297
+		infiniband_switch_port_unicast_transmit_packets_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 387471005571
+		infiniband_switch_port_unicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 101708165289
+		infiniband_switch_port_unicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 122978948297
 		# HELP infiniband_switch_port_vl_mapping_errors_total Infiniband switch port PortVLMappingErrors
 		# TYPE infiniband_switch_port_vl_mapping_errors_total counter
-		infiniband_switch_port_vl_mapping_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_vl_mapping_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_vl_mapping_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_vl_mapping_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_vl_mapping_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_vl_mapping_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_vl15_dropped_total Infiniband switch port VL15Dropped
 		# TYPE infiniband_switch_port_vl15_dropped_total counter
-		infiniband_switch_port_vl15_dropped_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_vl15_dropped_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_vl15_dropped_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_vl15_dropped_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_vl15_dropped_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_vl15_dropped_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_uplink_info Infiniband switch uplink information
 		# TYPE infiniband_switch_uplink_info gauge
 		infiniband_switch_uplink_info{guid="0x506b4b03005c2740",port="35",switch="ib-i4l1s01",uplink="p0001 HCA-1",uplink_guid="0x506b4b0300cc02a6",uplink_lid="1432",uplink_port="1",uplink_type="CA"} 1
@@ -410,34 +410,34 @@ func TestSwitchCollectorNoBase(t *testing.T) {
 		infiniband_exporter_collect_timeouts{collector="switch"} 0
 		# HELP infiniband_switch_port_buffer_overrun_errors_total Infiniband switch port PortBufferOverrunErrors
 		# TYPE infiniband_switch_port_buffer_overrun_errors_total counter
-		infiniband_switch_port_buffer_overrun_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_buffer_overrun_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_buffer_overrun_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_buffer_overrun_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_buffer_overrun_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_buffer_overrun_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_dli_mapping_errors_total Infiniband switch port PortDLIDMappingErrors
 		# TYPE infiniband_switch_port_dli_mapping_errors_total counter
-		infiniband_switch_port_dli_mapping_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_dli_mapping_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_dli_mapping_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_dli_mapping_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_dli_mapping_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_dli_mapping_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_local_physical_errors_total Infiniband switch port PortLocalPhysicalErrors
 		# TYPE infiniband_switch_port_local_physical_errors_total counter
-		infiniband_switch_port_local_physical_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_local_physical_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_local_physical_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_local_physical_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_local_physical_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_local_physical_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_looping_errors_total Infiniband switch port PortLoopingErrors
 		# TYPE infiniband_switch_port_looping_errors_total counter
-		infiniband_switch_port_looping_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_looping_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_looping_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_looping_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_looping_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_looping_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_malformed_packet_errors_total Infiniband switch port PortMalformedPktErrors
 		# TYPE infiniband_switch_port_malformed_packet_errors_total counter
-		infiniband_switch_port_malformed_packet_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_malformed_packet_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_malformed_packet_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_malformed_packet_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_malformed_packet_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_malformed_packet_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 		# HELP infiniband_switch_port_vl_mapping_errors_total Infiniband switch port PortVLMappingErrors
 		# TYPE infiniband_switch_port_vl_mapping_errors_total counter
-		infiniband_switch_port_vl_mapping_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-		infiniband_switch_port_vl_mapping_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-		infiniband_switch_port_vl_mapping_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+		infiniband_switch_port_vl_mapping_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_vl_mapping_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+		infiniband_switch_port_vl_mapping_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 	`
 	collector := NewSwitchCollector(&switchDevices, false, log.NewNopLogger())
 	gatherers := setupGatherer(collector)

--- a/examples/infiniband.rules
+++ b/examples/infiniband.rules
@@ -207,6 +207,19 @@ groups:
     expr: sum(infiniband:switch_port_qp1_dropped:irate5m) without (host, port, uplink, uplink_port)
   - record: infiniband:switch_port_qp1_dropped:switch_rate5m
     expr: sum(infiniband:switch_port_qp1_dropped:irate5m) without (host, port, uplink, uplink_port)
+- name: infiniband-port-state
+  rules:
+  - record: infiniband:switch_port_ever_connected
+    expr: max_over_time(infiniband_switch_port_state[30d]) == 1
+  - alert: InfinibandSwitchPortDown
+    expr: infiniband_switch_port_state == 0 and infiniband:switch_port_ever_connected
+    for: 5m
+    labels:
+      severity: warning
+      alertgroup: infiniband
+    annotations:
+      title: InfiniBand switch {{ $labels.switch }} port {{ $labels.port }} is down
+      description: Switch {{ $labels.switch }} ({{ $labels.guid }}) port {{ $labels.port }} link is down
 - name: infiniband
   rules:
   - alert: InfinibandCollectError

--- a/infiniband_exporter_test.go
+++ b/infiniband_exporter_test.go
@@ -41,126 +41,126 @@ infiniband_switch_info{guid="0x506b4b03005c2740",lid="2052",switch="ib-i4l1s01"}
 infiniband_switch_info{guid="0x7cfe9003009ce5b0",lid="1719",switch="ib-i1l1s01"} 1
 # HELP infiniband_switch_port_excessive_buffer_overrun_errors_total Infiniband switch port ExcessiveBufferOverrunErrors
 # TYPE infiniband_switch_port_excessive_buffer_overrun_errors_total counter
-infiniband_switch_port_excessive_buffer_overrun_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-infiniband_switch_port_excessive_buffer_overrun_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-infiniband_switch_port_excessive_buffer_overrun_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+infiniband_switch_port_excessive_buffer_overrun_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+infiniband_switch_port_excessive_buffer_overrun_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+infiniband_switch_port_excessive_buffer_overrun_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 # HELP infiniband_switch_port_link_downed_total Infiniband switch port LinkDownedCounter
 # TYPE infiniband_switch_port_link_downed_total counter
-infiniband_switch_port_link_downed_total{guid="0x506b4b03005c2740",port="1"} 1
-infiniband_switch_port_link_downed_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-infiniband_switch_port_link_downed_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+infiniband_switch_port_link_downed_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 1
+infiniband_switch_port_link_downed_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+infiniband_switch_port_link_downed_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 # HELP infiniband_switch_port_link_error_recovery_total Infiniband switch port LinkErrorRecoveryCounter
 # TYPE infiniband_switch_port_link_error_recovery_total counter
-infiniband_switch_port_link_error_recovery_total{guid="0x506b4b03005c2740",port="1"} 0
-infiniband_switch_port_link_error_recovery_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-infiniband_switch_port_link_error_recovery_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+infiniband_switch_port_link_error_recovery_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+infiniband_switch_port_link_error_recovery_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+infiniband_switch_port_link_error_recovery_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 # HELP infiniband_switch_port_local_link_integrity_errors_total Infiniband switch port LocalLinkIntegrityErrors
 # TYPE infiniband_switch_port_local_link_integrity_errors_total counter
-infiniband_switch_port_local_link_integrity_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-infiniband_switch_port_local_link_integrity_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-infiniband_switch_port_local_link_integrity_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+infiniband_switch_port_local_link_integrity_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+infiniband_switch_port_local_link_integrity_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+infiniband_switch_port_local_link_integrity_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 # HELP infiniband_switch_port_multicast_receive_packets_total Infiniband switch port PortMulticastRcvPkts
 # TYPE infiniband_switch_port_multicast_receive_packets_total counter
-infiniband_switch_port_multicast_receive_packets_total{guid="0x506b4b03005c2740",port="1"} 6.69494e+06
-infiniband_switch_port_multicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="1"} 5.584846741e+09
-infiniband_switch_port_multicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+infiniband_switch_port_multicast_receive_packets_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 6.69494e+06
+infiniband_switch_port_multicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 5.584846741e+09
+infiniband_switch_port_multicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 # HELP infiniband_switch_port_multicast_transmit_packets_total Infiniband switch port PortMulticastXmitPkts
 # TYPE infiniband_switch_port_multicast_transmit_packets_total counter
-infiniband_switch_port_multicast_transmit_packets_total{guid="0x506b4b03005c2740",port="1"} 5.623645694e+09
-infiniband_switch_port_multicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="1"} 2.5038914e+07
-infiniband_switch_port_multicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+infiniband_switch_port_multicast_transmit_packets_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 5.623645694e+09
+infiniband_switch_port_multicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 2.5038914e+07
+infiniband_switch_port_multicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 # HELP infiniband_switch_port_qp1_dropped_total Infiniband switch port QP1Dropped
 # TYPE infiniband_switch_port_qp1_dropped_total counter
-infiniband_switch_port_qp1_dropped_total{guid="0x506b4b03005c2740",port="1"} 0
-infiniband_switch_port_qp1_dropped_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-infiniband_switch_port_qp1_dropped_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+infiniband_switch_port_qp1_dropped_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+infiniband_switch_port_qp1_dropped_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+infiniband_switch_port_qp1_dropped_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 # HELP infiniband_switch_port_rate_bytes_per_second Infiniband switch port rate
 # TYPE infiniband_switch_port_rate_bytes_per_second gauge
-infiniband_switch_port_rate_bytes_per_second{guid="0x506b4b03005c2740",port="35"} 1.25e+10
-infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="1"} 1.25e+10
-infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="10"} 1.25e+10
-infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="11"} 1.25e+10
+infiniband_switch_port_rate_bytes_per_second{guid="0x506b4b03005c2740",port="35",switch="ib-i4l1s01"} 1.25e+10
+infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 1.25e+10
+infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="10",switch="ib-i1l1s01"} 1.25e+10
+infiniband_switch_port_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="11",switch="ib-i1l1s01"} 1.25e+10
 # HELP infiniband_switch_port_raw_rate_bytes_per_second Infiniband switch port raw rate
 # TYPE infiniband_switch_port_raw_rate_bytes_per_second gauge
-infiniband_switch_port_raw_rate_bytes_per_second{guid="0x506b4b03005c2740",port="35"} 1.2890625e+10
-infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="1"} 1.2890625e+10
-infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="10"} 1.2890625e+10
-infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="11"} 1.2890625e+10
+infiniband_switch_port_raw_rate_bytes_per_second{guid="0x506b4b03005c2740",port="35",switch="ib-i4l1s01"} 1.2890625e+10
+infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 1.2890625e+10
+infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="10",switch="ib-i1l1s01"} 1.2890625e+10
+infiniband_switch_port_raw_rate_bytes_per_second{guid="0x7cfe9003009ce5b0",port="11",switch="ib-i1l1s01"} 1.2890625e+10
 # HELP infiniband_switch_port_receive_constraint_errors_total Infiniband switch port PortRcvConstraintErrors
 # TYPE infiniband_switch_port_receive_constraint_errors_total counter
-infiniband_switch_port_receive_constraint_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-infiniband_switch_port_receive_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-infiniband_switch_port_receive_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+infiniband_switch_port_receive_constraint_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+infiniband_switch_port_receive_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+infiniband_switch_port_receive_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 # HELP infiniband_switch_port_receive_data_bytes_total Infiniband switch port PortRcvData
 # TYPE infiniband_switch_port_receive_data_bytes_total counter
-infiniband_switch_port_receive_data_bytes_total{guid="0x506b4b03005c2740",port="1"} 7.15049367846516e+14
-infiniband_switch_port_receive_data_bytes_total{guid="0x7cfe9003009ce5b0",port="1"} 4.9116115103004e+13
-infiniband_switch_port_receive_data_bytes_total{guid="0x7cfe9003009ce5b0",port="2"} 1.56315219973512e+14
+infiniband_switch_port_receive_data_bytes_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 7.15049367846516e+14
+infiniband_switch_port_receive_data_bytes_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 4.9116115103004e+13
+infiniband_switch_port_receive_data_bytes_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 1.56315219973512e+14
 # HELP infiniband_switch_port_receive_errors_total Infiniband switch port PortRcvErrors
 # TYPE infiniband_switch_port_receive_errors_total counter
-infiniband_switch_port_receive_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-infiniband_switch_port_receive_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-infiniband_switch_port_receive_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+infiniband_switch_port_receive_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+infiniband_switch_port_receive_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+infiniband_switch_port_receive_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 # HELP infiniband_switch_port_receive_packets_total Infiniband switch port PortRcvPkts
 # TYPE infiniband_switch_port_receive_packets_total counter
-infiniband_switch_port_receive_packets_total{guid="0x506b4b03005c2740",port="1"} 3.87654829341e+11
-infiniband_switch_port_receive_packets_total{guid="0x7cfe9003009ce5b0",port="1"} 3.2262508468e+10
-infiniband_switch_port_receive_packets_total{guid="0x7cfe9003009ce5b0",port="2"} 9.3660802641e+10
+infiniband_switch_port_receive_packets_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 3.87654829341e+11
+infiniband_switch_port_receive_packets_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 3.2262508468e+10
+infiniband_switch_port_receive_packets_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 9.3660802641e+10
 # HELP infiniband_switch_port_receive_remote_physical_errors_total Infiniband switch port PortRcvRemotePhysicalErrors
 # TYPE infiniband_switch_port_receive_remote_physical_errors_total counter
-infiniband_switch_port_receive_remote_physical_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-infiniband_switch_port_receive_remote_physical_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-infiniband_switch_port_receive_remote_physical_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+infiniband_switch_port_receive_remote_physical_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+infiniband_switch_port_receive_remote_physical_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+infiniband_switch_port_receive_remote_physical_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 # HELP infiniband_switch_port_receive_switch_relay_errors_total Infiniband switch port PortRcvSwitchRelayErrors
 # TYPE infiniband_switch_port_receive_switch_relay_errors_total counter
-infiniband_switch_port_receive_switch_relay_errors_total{guid="0x506b4b03005c2740",port="1"} 7
-infiniband_switch_port_receive_switch_relay_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-infiniband_switch_port_receive_switch_relay_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+infiniband_switch_port_receive_switch_relay_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 7
+infiniband_switch_port_receive_switch_relay_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+infiniband_switch_port_receive_switch_relay_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 # HELP infiniband_switch_port_symbol_error_total Infiniband switch port SymbolErrorCounter
 # TYPE infiniband_switch_port_symbol_error_total counter
-infiniband_switch_port_symbol_error_total{guid="0x506b4b03005c2740",port="1"} 0
-infiniband_switch_port_symbol_error_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-infiniband_switch_port_symbol_error_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+infiniband_switch_port_symbol_error_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+infiniband_switch_port_symbol_error_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+infiniband_switch_port_symbol_error_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 # HELP infiniband_switch_port_transmit_constraint_errors_total Infiniband switch port PortXmitConstraintErrors
 # TYPE infiniband_switch_port_transmit_constraint_errors_total counter
-infiniband_switch_port_transmit_constraint_errors_total{guid="0x506b4b03005c2740",port="1"} 0
-infiniband_switch_port_transmit_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-infiniband_switch_port_transmit_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+infiniband_switch_port_transmit_constraint_errors_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+infiniband_switch_port_transmit_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+infiniband_switch_port_transmit_constraint_errors_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 # HELP infiniband_switch_port_transmit_data_bytes_total Infiniband switch port PortXmitData
 # TYPE infiniband_switch_port_transmit_data_bytes_total counter
-infiniband_switch_port_transmit_data_bytes_total{guid="0x506b4b03005c2740",port="1"} 7.1516662870894e+14
-infiniband_switch_port_transmit_data_bytes_total{guid="0x7cfe9003009ce5b0",port="1"} 1.45192107443712e+14
-infiniband_switch_port_transmit_data_bytes_total{guid="0x7cfe9003009ce5b0",port="2"} 1.04026280056104e+14
+infiniband_switch_port_transmit_data_bytes_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 7.1516662870894e+14
+infiniband_switch_port_transmit_data_bytes_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 1.45192107443712e+14
+infiniband_switch_port_transmit_data_bytes_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 1.04026280056104e+14
 # HELP infiniband_switch_port_transmit_discards_total Infiniband switch port PortXmitDiscards
 # TYPE infiniband_switch_port_transmit_discards_total counter
-infiniband_switch_port_transmit_discards_total{guid="0x506b4b03005c2740",port="1"} 20046
-infiniband_switch_port_transmit_discards_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-infiniband_switch_port_transmit_discards_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+infiniband_switch_port_transmit_discards_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 20046
+infiniband_switch_port_transmit_discards_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+infiniband_switch_port_transmit_discards_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 # HELP infiniband_switch_port_transmit_packets_total Infiniband switch port PortXmitPkts
 # TYPE infiniband_switch_port_transmit_packets_total counter
-infiniband_switch_port_transmit_packets_total{guid="0x506b4b03005c2740",port="1"} 3.93094651266e+11
-infiniband_switch_port_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="1"} 1.01733204203e+11
-infiniband_switch_port_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="2"} 1.22978948297e+11
+infiniband_switch_port_transmit_packets_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 3.93094651266e+11
+infiniband_switch_port_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 1.01733204203e+11
+infiniband_switch_port_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 1.22978948297e+11
 # HELP infiniband_switch_port_transmit_wait_total Infiniband switch port PortXmitWait
 # TYPE infiniband_switch_port_transmit_wait_total counter
-infiniband_switch_port_transmit_wait_total{guid="0x506b4b03005c2740",port="1"} 4.1864608e+07
-infiniband_switch_port_transmit_wait_total{guid="0x7cfe9003009ce5b0",port="1"} 2.2730501e+07
-infiniband_switch_port_transmit_wait_total{guid="0x7cfe9003009ce5b0",port="2"} 3.6510964e+07
+infiniband_switch_port_transmit_wait_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 4.1864608e+07
+infiniband_switch_port_transmit_wait_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 2.2730501e+07
+infiniband_switch_port_transmit_wait_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 3.6510964e+07
 # HELP infiniband_switch_port_unicast_receive_packets_total Infiniband switch port PortUnicastRcvPkts
 # TYPE infiniband_switch_port_unicast_receive_packets_total counter
-infiniband_switch_port_unicast_receive_packets_total{guid="0x506b4b03005c2740",port="1"} 3.876481344e+11
-infiniband_switch_port_unicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="1"} 2.6677661727e+10
-infiniband_switch_port_unicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="2"} 9.3660802641e+10
+infiniband_switch_port_unicast_receive_packets_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 3.876481344e+11
+infiniband_switch_port_unicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 2.6677661727e+10
+infiniband_switch_port_unicast_receive_packets_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 9.3660802641e+10
 # HELP infiniband_switch_port_unicast_transmit_packets_total Infiniband switch port PortUnicastXmitPkts
 # TYPE infiniband_switch_port_unicast_transmit_packets_total counter
-infiniband_switch_port_unicast_transmit_packets_total{guid="0x506b4b03005c2740",port="1"} 3.87471005571e+11
-infiniband_switch_port_unicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="1"} 1.01708165289e+11
-infiniband_switch_port_unicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="2"} 1.22978948297e+11
+infiniband_switch_port_unicast_transmit_packets_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 3.87471005571e+11
+infiniband_switch_port_unicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 1.01708165289e+11
+infiniband_switch_port_unicast_transmit_packets_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 1.22978948297e+11
 # HELP infiniband_switch_port_vl15_dropped_total Infiniband switch port VL15Dropped
 # TYPE infiniband_switch_port_vl15_dropped_total counter
-infiniband_switch_port_vl15_dropped_total{guid="0x506b4b03005c2740",port="1"} 0
-infiniband_switch_port_vl15_dropped_total{guid="0x7cfe9003009ce5b0",port="1"} 0
-infiniband_switch_port_vl15_dropped_total{guid="0x7cfe9003009ce5b0",port="2"} 0
+infiniband_switch_port_vl15_dropped_total{guid="0x506b4b03005c2740",port="1",switch="ib-i4l1s01"} 0
+infiniband_switch_port_vl15_dropped_total{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 0
+infiniband_switch_port_vl15_dropped_total{guid="0x7cfe9003009ce5b0",port="2",switch="ib-i1l1s01"} 0
 # HELP infiniband_switch_uplink_info Infiniband switch uplink information
 # TYPE infiniband_switch_uplink_info gauge
 infiniband_switch_uplink_info{guid="0x506b4b03005c2740",port="35",switch="ib-i4l1s01",uplink="p0001 HCA-1",uplink_guid="0x506b4b0300cc02a6",uplink_lid="1432",uplink_port="1",uplink_type="CA"} 1
@@ -169,59 +169,59 @@ infiniband_switch_uplink_info{guid="0x7cfe9003009ce5b0",port="10",switch="ib-i1l
 infiniband_switch_uplink_info{guid="0x7cfe9003009ce5b0",port="11",switch="ib-i1l1s01",uplink="o0002 HCA-1",uplink_guid="0x7cfe9003003b4b96",uplink_lid="133",uplink_port="1",uplink_type="CA"} 1`
 	expectedIbswinfo = `# HELP infiniband_switch_fan_rpm Infiniband switch fan RPM
 # TYPE infiniband_switch_fan_rpm gauge
-infiniband_switch_fan_rpm{fan="1",guid="0x506b4b03005c2740"} 6125
-infiniband_switch_fan_rpm{fan="1",guid="0x7cfe9003009ce5b0"} 8493
-infiniband_switch_fan_rpm{fan="2",guid="0x506b4b03005c2740"} 5251
-infiniband_switch_fan_rpm{fan="2",guid="0x7cfe9003009ce5b0"} 7349
-infiniband_switch_fan_rpm{fan="3",guid="0x506b4b03005c2740"} 6013
-infiniband_switch_fan_rpm{fan="3",guid="0x7cfe9003009ce5b0"} 8441
-infiniband_switch_fan_rpm{fan="4",guid="0x506b4b03005c2740"} 5335
-infiniband_switch_fan_rpm{fan="4",guid="0x7cfe9003009ce5b0"} 7270
-infiniband_switch_fan_rpm{fan="5",guid="0x506b4b03005c2740"} 6068
-infiniband_switch_fan_rpm{fan="5",guid="0x7cfe9003009ce5b0"} 8337
-infiniband_switch_fan_rpm{fan="6",guid="0x506b4b03005c2740"} 5423
-infiniband_switch_fan_rpm{fan="6",guid="0x7cfe9003009ce5b0"} 7156
-infiniband_switch_fan_rpm{fan="7",guid="0x506b4b03005c2740"} 5854
-infiniband_switch_fan_rpm{fan="7",guid="0x7cfe9003009ce5b0"} 8441
-infiniband_switch_fan_rpm{fan="8",guid="0x506b4b03005c2740"} 5467
-infiniband_switch_fan_rpm{fan="8",guid="0x7cfe9003009ce5b0"} 7232
-infiniband_switch_fan_rpm{fan="9",guid="0x506b4b03005c2740"} 5906
+infiniband_switch_fan_rpm{fan="1",guid="0x506b4b03005c2740",switch="ib-i4l1s01"} 6125
+infiniband_switch_fan_rpm{fan="1",guid="0x7cfe9003009ce5b0",switch="ib-i1l1s01"} 8493
+infiniband_switch_fan_rpm{fan="2",guid="0x506b4b03005c2740",switch="ib-i4l1s01"} 5251
+infiniband_switch_fan_rpm{fan="2",guid="0x7cfe9003009ce5b0",switch="ib-i1l1s01"} 7349
+infiniband_switch_fan_rpm{fan="3",guid="0x506b4b03005c2740",switch="ib-i4l1s01"} 6013
+infiniband_switch_fan_rpm{fan="3",guid="0x7cfe9003009ce5b0",switch="ib-i1l1s01"} 8441
+infiniband_switch_fan_rpm{fan="4",guid="0x506b4b03005c2740",switch="ib-i4l1s01"} 5335
+infiniband_switch_fan_rpm{fan="4",guid="0x7cfe9003009ce5b0",switch="ib-i1l1s01"} 7270
+infiniband_switch_fan_rpm{fan="5",guid="0x506b4b03005c2740",switch="ib-i4l1s01"} 6068
+infiniband_switch_fan_rpm{fan="5",guid="0x7cfe9003009ce5b0",switch="ib-i1l1s01"} 8337
+infiniband_switch_fan_rpm{fan="6",guid="0x506b4b03005c2740",switch="ib-i4l1s01"} 5423
+infiniband_switch_fan_rpm{fan="6",guid="0x7cfe9003009ce5b0",switch="ib-i1l1s01"} 7156
+infiniband_switch_fan_rpm{fan="7",guid="0x506b4b03005c2740",switch="ib-i4l1s01"} 5854
+infiniband_switch_fan_rpm{fan="7",guid="0x7cfe9003009ce5b0",switch="ib-i1l1s01"} 8441
+infiniband_switch_fan_rpm{fan="8",guid="0x506b4b03005c2740",switch="ib-i4l1s01"} 5467
+infiniband_switch_fan_rpm{fan="8",guid="0x7cfe9003009ce5b0",switch="ib-i1l1s01"} 7232
+infiniband_switch_fan_rpm{fan="9",guid="0x506b4b03005c2740",switch="ib-i4l1s01"} 5906
 # HELP infiniband_switch_fan_status_info Infiniband switch fan status
 # TYPE infiniband_switch_fan_status_info gauge
-infiniband_switch_fan_status_info{guid="0x506b4b03005c2740",status="OK"} 1
-infiniband_switch_fan_status_info{guid="0x7cfe9003009ce5b0",status="ERROR"} 1
+infiniband_switch_fan_status_info{guid="0x506b4b03005c2740",status="OK",switch="ib-i4l1s01"} 1
+infiniband_switch_fan_status_info{guid="0x7cfe9003009ce5b0",status="ERROR",switch="ib-i1l1s01"} 1
 # HELP infiniband_switch_hardware_info Infiniband switch hardware info
 # TYPE infiniband_switch_hardware_info gauge
 infiniband_switch_hardware_info{firmware_version="11.2008.2102",guid="0x7cfe9003009ce5b0",part_number="MSB7790-ES2F",psid="MT_1880110032",serial_number="MT1943X00498",switch="ib-i1l1s01"} 1
 infiniband_switch_hardware_info{firmware_version="27.2010.3118",guid="0x506b4b03005c2740",part_number="MQM8790-HS2F",psid="MT_0000000063",serial_number="MT2152T10239",switch="ib-i4l1s01"} 1
 # HELP infiniband_switch_power_supply_dc_power_status_info Infiniband switch power supply DC power status
 # TYPE infiniband_switch_power_supply_dc_power_status_info gauge
-infiniband_switch_power_supply_dc_power_status_info{guid="0x506b4b03005c2740",psu="0",status="OK"} 1
-infiniband_switch_power_supply_dc_power_status_info{guid="0x506b4b03005c2740",psu="1",status="OK"} 1
-infiniband_switch_power_supply_dc_power_status_info{guid="0x7cfe9003009ce5b0",psu="0",status="OK"} 1
-infiniband_switch_power_supply_dc_power_status_info{guid="0x7cfe9003009ce5b0",psu="1",status="OK"} 1
+infiniband_switch_power_supply_dc_power_status_info{guid="0x506b4b03005c2740",psu="0",status="OK",switch="ib-i4l1s01"} 1
+infiniband_switch_power_supply_dc_power_status_info{guid="0x506b4b03005c2740",psu="1",status="OK",switch="ib-i4l1s01"} 1
+infiniband_switch_power_supply_dc_power_status_info{guid="0x7cfe9003009ce5b0",psu="0",status="OK",switch="ib-i1l1s01"} 1
+infiniband_switch_power_supply_dc_power_status_info{guid="0x7cfe9003009ce5b0",psu="1",status="OK",switch="ib-i1l1s01"} 1
 # HELP infiniband_switch_power_supply_fan_status_info Infiniband switch power supply fan status
 # TYPE infiniband_switch_power_supply_fan_status_info gauge
-infiniband_switch_power_supply_fan_status_info{guid="0x506b4b03005c2740",psu="0",status="OK"} 1
-infiniband_switch_power_supply_fan_status_info{guid="0x506b4b03005c2740",psu="1",status="OK"} 1
-infiniband_switch_power_supply_fan_status_info{guid="0x7cfe9003009ce5b0",psu="0",status="OK"} 1
-infiniband_switch_power_supply_fan_status_info{guid="0x7cfe9003009ce5b0",psu="1",status="OK"} 1
+infiniband_switch_power_supply_fan_status_info{guid="0x506b4b03005c2740",psu="0",status="OK",switch="ib-i4l1s01"} 1
+infiniband_switch_power_supply_fan_status_info{guid="0x506b4b03005c2740",psu="1",status="OK",switch="ib-i4l1s01"} 1
+infiniband_switch_power_supply_fan_status_info{guid="0x7cfe9003009ce5b0",psu="0",status="OK",switch="ib-i1l1s01"} 1
+infiniband_switch_power_supply_fan_status_info{guid="0x7cfe9003009ce5b0",psu="1",status="OK",switch="ib-i1l1s01"} 1
 # HELP infiniband_switch_power_supply_status_info Infiniband switch power supply status
 # TYPE infiniband_switch_power_supply_status_info gauge
-infiniband_switch_power_supply_status_info{guid="0x506b4b03005c2740",psu="0",status="OK"} 1
-infiniband_switch_power_supply_status_info{guid="0x506b4b03005c2740",psu="1",status="OK"} 1
-infiniband_switch_power_supply_status_info{guid="0x7cfe9003009ce5b0",psu="0",status="OK"} 1
-infiniband_switch_power_supply_status_info{guid="0x7cfe9003009ce5b0",psu="1",status="OK"} 1
+infiniband_switch_power_supply_status_info{guid="0x506b4b03005c2740",psu="0",status="OK",switch="ib-i4l1s01"} 1
+infiniband_switch_power_supply_status_info{guid="0x506b4b03005c2740",psu="1",status="OK",switch="ib-i4l1s01"} 1
+infiniband_switch_power_supply_status_info{guid="0x7cfe9003009ce5b0",psu="0",status="OK",switch="ib-i1l1s01"} 1
+infiniband_switch_power_supply_status_info{guid="0x7cfe9003009ce5b0",psu="1",status="OK",switch="ib-i1l1s01"} 1
 # HELP infiniband_switch_power_supply_watts Infiniband switch power supply watts
 # TYPE infiniband_switch_power_supply_watts gauge
-infiniband_switch_power_supply_watts{guid="0x506b4b03005c2740",psu="0"} 154
-infiniband_switch_power_supply_watts{guid="0x506b4b03005c2740",psu="1"} 134
-infiniband_switch_power_supply_watts{guid="0x7cfe9003009ce5b0",psu="0"} 72
-infiniband_switch_power_supply_watts{guid="0x7cfe9003009ce5b0",psu="1"} 71
+infiniband_switch_power_supply_watts{guid="0x506b4b03005c2740",psu="0",switch="ib-i4l1s01"} 154
+infiniband_switch_power_supply_watts{guid="0x506b4b03005c2740",psu="1",switch="ib-i4l1s01"} 134
+infiniband_switch_power_supply_watts{guid="0x7cfe9003009ce5b0",psu="0",switch="ib-i1l1s01"} 72
+infiniband_switch_power_supply_watts{guid="0x7cfe9003009ce5b0",psu="1",switch="ib-i1l1s01"} 71
 # HELP infiniband_switch_temperature_celsius Infiniband switch temperature celsius
 # TYPE infiniband_switch_temperature_celsius gauge
-infiniband_switch_temperature_celsius{guid="0x506b4b03005c2740"} 53
-infiniband_switch_temperature_celsius{guid="0x7cfe9003009ce5b0"} 45`
+infiniband_switch_temperature_celsius{guid="0x506b4b03005c2740",switch="ib-i4l1s01"} 53
+infiniband_switch_temperature_celsius{guid="0x7cfe9003009ce5b0",switch="ib-i1l1s01"} 45`
 	expectedHCA = `# HELP infiniband_hca_info Infiniband HCA information
 # TYPE infiniband_hca_info gauge
 infiniband_hca_info{guid="0x506b4b0300cc02a6",hca="p0001 HCA-1",lid="1432"} 1


### PR DESCRIPTION
Adds a `switch` label containing device’s hostname (or whatever ibnetdiscover reports) to every switch metric improving readability.

The label stays present even if `--ibnetdiscover.node-name-map` was not provided.