### PR TITLE
"infiniband_switch_port_state" gauge for persistent link-down detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,13 @@ Collectors are enabled or disabled via `--collector.<name>` and `--no-collector.
 Name | Description | Default
 -----|-------------|--------
 switch | Collect switch port counters | Enabled
+switch.base-metrics | Collect base switch metrics | Enabled
+switch.rcv-err-details | Collect receive error details | Disabled
+switch.port-state | Report switch port link state (1=up, 0=down) | Disabled
 ibswinfo | Collect data on unmanaged switches via ibswinfo (BETA) | Disabled
 hca | Collect HCA port counters | Disabled
+hca.base-metrics | Collect base HCA metrics | Enabled
+hca.rcv-err-details | Collect receive error details | Disabled
 
 If you have a node name map file typically used with Subnet Managers, you can provide that file to the  `--ibnetdiscover.node-name-map` flag.  This will use friendly names for switches.
 
@@ -54,6 +59,14 @@ This feature is considered BETA as it relies on parsing non-machine readable dat
 In the future this exporter may collect the unmanaged switch information directly in a similar way to what ibswinfo is doing.
 
 The collection of `ibswinfo` takes about 2-3 seconds per switch so consider increasing Prometheus scrape timeout or running using `--exporter.runonce` per [Large fabric considerations](#large-fabric-considerations).  Also consider increasing the `--ibswinfo.max-concurrent` to a value greater than the default of 1, but be aware that a value too high will cause timeouts executing concurrent `ibswinfo` commands.
+
+### Port link state monitoring
+
+By default, when a port link goes down the exporter stops emitting metrics for that port (the time series becomes stale). This makes it difficult to alert on link failures in Prometheus.
+
+Enabling `--collector.switch.port-state` adds `infiniband_switch_port_state{guid, switch, port}` — a gauge that reports `1` when up, `0` when down. Disconnected ports (reported as `???` by `ibnetdiscover`) persistently emit `0` on every scrape.
+
+See `examples/infiniband.rules` for recording rules and alert examples.
 
 ### Large fabric considerations
 

--- a/collectors/collectors_test.go
+++ b/collectors/collectors_test.go
@@ -34,6 +34,7 @@ var (
 			Uplinks: map[string]InfinibandUplink{
 				"35": {Type: "CA", LID: "1432", PortNumber: "1", GUID: "0x506b4b0300cc02a6", Name: "p0001 HCA-1", Rate: (25 * 4 * 125000000), RawRate: 1.2890625e+10},
 			},
+			DownPorts: []string{"37"},
 		},
 		{Type: "SW", LID: "1719", GUID: "0x7cfe9003009ce5b0", Name: "ib-i1l1s01",
 			Uplinks: map[string]InfinibandUplink{

--- a/collectors/ibnetdiscover.go
+++ b/collectors/ibnetdiscover.go
@@ -51,13 +51,14 @@ var (
 )
 
 type InfinibandDevice struct {
-	Type    string
-	LID     string
-	GUID    string
-	Rate    float64
-	RawRate float64
-	Name    string
-	Uplinks map[string]InfinibandUplink
+	Type      string
+	LID       string
+	GUID      string
+	Rate      float64
+	RawRate   float64
+	Name      string
+	Uplinks   map[string]InfinibandUplink
+	DownPorts []string
 }
 
 type InfinibandUplink struct {
@@ -137,7 +138,27 @@ func ibnetdiscoverParse(out string, logger log.Logger) (*[]InfinibandDevice, *[]
 			continue
 		}
 		if items[5] == "???" {
-			level.Debug(logger).Log("msg", "Skipping line that is not connected", "line", line)
+			if !*switchCollectPortState {
+				level.Debug(logger).Log("msg", "Skipping line that is not connected", "line", line)
+				continue
+			}
+			guid := items[3]
+			portNumber := items[2]
+			device, ok := devices[guid]
+			if !ok {
+				device.Uplinks = make(map[string]InfinibandUplink)
+			}
+			device.Type = items[0]
+			device.LID = items[1]
+			device.GUID = guid
+			portName, _, err := parseNames(line)
+			if err != nil {
+				level.Debug(logger).Log("msg", "Unable to parse name for down port, skipping", "line", line)
+				continue
+			}
+			device.Name = portName
+			device.DownPorts = append(device.DownPorts, portNumber)
+			devices[guid] = device
 			continue
 		}
 		// check the last item, because name may have space so that it is split into multiple items

--- a/collectors/ibnetdiscover_test.go
+++ b/collectors/ibnetdiscover_test.go
@@ -195,6 +195,34 @@ func TestIbnetdiscoverParse(t *testing.T) {
 	}
 }
 
+func TestIbnetdiscoverParsePortState(t *testing.T) {
+	*switchCollectPortState = true
+	defer func() { *switchCollectPortState = false }()
+	out, err := ReadFixture("ibnetdiscover", "test")
+	if err != nil {
+		t.Fatal("Unable to read fixture")
+	}
+	w := log.NewSyncWriter(os.Stderr)
+	logger := log.NewLogfmtLogger(w)
+	switches, _, err := ibnetdiscoverParse(out, logger)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+		return
+	}
+	var found bool
+	for _, sw := range *switches {
+		if sw.GUID == "0x506b4b03005c2740" {
+			found = true
+			if len(sw.DownPorts) != 1 || sw.DownPorts[0] != "37" {
+				t.Errorf("Expected DownPorts [37], got %v", sw.DownPorts)
+			}
+		}
+	}
+	if !found {
+		t.Error("Switch 0x506b4b03005c2740 not found")
+	}
+}
+
 func TestIbnetdiscoverParse2(t *testing.T) {
 	expectedHCAs := []InfinibandDevice{
 		{Type: "CA", LID: "78", GUID: "0x946dae0300630bfe", Rate: 50 * 4 * 125000000, RawRate: 50 * 4 * 125000000, Name: "Mellanox Technologies Aggregation Node",

--- a/collectors/switch.go
+++ b/collectors/switch.go
@@ -28,9 +28,10 @@ import (
 )
 
 var (
-	CollectSwitch       = kingpin.Flag("collector.switch", "Enable the switch collector").Default("true").Bool()
-	switchCollectBase   = kingpin.Flag("collector.switch.base-metrics", "Collect base metrics").Default("true").Bool()
-	switchCollectRcvErr = kingpin.Flag("collector.switch.rcv-err-details", "Collect Rcv Error Details").Default("false").Bool()
+	CollectSwitch          = kingpin.Flag("collector.switch", "Enable the switch collector").Default("true").Bool()
+	switchCollectBase      = kingpin.Flag("collector.switch.base-metrics", "Collect base metrics").Default("true").Bool()
+	switchCollectRcvErr    = kingpin.Flag("collector.switch.rcv-err-details", "Collect Rcv Error Details").Default("false").Bool()
+	switchCollectPortState = kingpin.Flag("collector.switch.port-state", "Report port link state (1=up, 0=down)").Default("false").Bool()
 )
 
 type SwitchCollector struct {
@@ -72,6 +73,7 @@ type SwitchCollector struct {
 	RawRate                      *prometheus.Desc
 	Uplink                       *prometheus.Desc
 	Info                         *prometheus.Desc
+	PortState                    *prometheus.Desc
 }
 
 type SwitchMetrics struct {
@@ -163,6 +165,8 @@ func NewSwitchCollector(devices *[]InfinibandDevice, runonce bool, logger log.Lo
 			"Infiniband switch uplink information", append(labels, []string{"switch", "uplink", "uplink_guid", "uplink_type", "uplink_port", "uplink_lid"}...), nil),
 		Info: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "info"),
 			"Infiniband switch information", []string{"guid", "switch", "lid"}, nil),
+		PortState: prometheus.NewDesc(prometheus.BuildFQName(namespace, "switch", "port_state"),
+			"Infiniband switch port link state (1=up, 0=down)", labels, nil),
 	}
 }
 
@@ -202,6 +206,7 @@ func (s *SwitchCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- s.RawRate
 	ch <- s.Uplink
 	ch <- s.Info
+	ch <- s.PortState
 }
 
 func (s *SwitchCollector) Collect(ch chan<- prometheus.Metric) {
@@ -313,6 +318,16 @@ func (s *SwitchCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(s.Duration, prometheus.GaugeValue, metric.rcvErrDuration, device.GUID, fmt.Sprintf("%s-rcv-err", s.collector))
 			ch <- prometheus.MustNewConstMetric(s.Timeout, prometheus.GaugeValue, metric.rcvErrTimeout, device.GUID, fmt.Sprintf("%s-rcv-err", s.collector))
 			ch <- prometheus.MustNewConstMetric(s.Error, prometheus.GaugeValue, metric.rcvErrError, device.GUID, fmt.Sprintf("%s-rcv-err", s.collector))
+		}
+	}
+	if *switchCollectPortState {
+		for _, device := range *s.devices {
+			for port := range device.Uplinks {
+				ch <- prometheus.MustNewConstMetric(s.PortState, prometheus.GaugeValue, 1, device.GUID, device.Name, port)
+			}
+			for _, port := range device.DownPorts {
+				ch <- prometheus.MustNewConstMetric(s.PortState, prometheus.GaugeValue, 0, device.GUID, device.Name, port)
+			}
 		}
 	}
 	ch <- prometheus.MustNewConstMetric(collectErrors, prometheus.GaugeValue, errors, s.collector)

--- a/collectors/switch_test.go
+++ b/collectors/switch_test.go
@@ -550,3 +550,41 @@ func TestSwitchCollectorTimeout(t *testing.T) {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
 }
+
+func TestSwitchCollectorPortState(t *testing.T) {
+	if _, err := kingpin.CommandLine.Parse([]string{"--collector.switch.port-state"}); err != nil {
+		t.Fatal(err)
+	}
+	SetPerfqueryExecs(t, false, false)
+	expected := `
+		# HELP infiniband_switch_port_state Infiniband switch port link state (1=up, 0=down)
+		# TYPE infiniband_switch_port_state gauge
+		infiniband_switch_port_state{guid="0x506b4b03005c2740",port="35",switch="ib-i4l1s01"} 1
+		infiniband_switch_port_state{guid="0x506b4b03005c2740",port="37",switch="ib-i4l1s01"} 0
+		infiniband_switch_port_state{guid="0x7cfe9003009ce5b0",port="1",switch="ib-i1l1s01"} 1
+		infiniband_switch_port_state{guid="0x7cfe9003009ce5b0",port="10",switch="ib-i1l1s01"} 1
+		infiniband_switch_port_state{guid="0x7cfe9003009ce5b0",port="11",switch="ib-i1l1s01"} 1
+	`
+	collector := NewSwitchCollector(&switchDevices, false, log.NewNopLogger())
+	gatherers := setupGatherer(collector)
+	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
+		"infiniband_switch_port_state"); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+}
+
+func TestSwitchCollectorPortStateDisabled(t *testing.T) {
+	if _, err := kingpin.CommandLine.Parse([]string{}); err != nil {
+		t.Fatal(err)
+	}
+	SetPerfqueryExecs(t, false, false)
+	collector := NewSwitchCollector(&switchDevices, false, log.NewNopLogger())
+	gatherers := setupGatherer(collector)
+	metrics, err := testutil.GatherAndCount(gatherers, "infiniband_switch_port_state")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if metrics != 0 {
+		t.Errorf("Expected 0 port_state metrics when disabled, got %d", metrics)
+	}
+}

--- a/examples/infiniband.rules
+++ b/examples/infiniband.rules
@@ -207,6 +207,19 @@ groups:
     expr: sum(infiniband:switch_port_qp1_dropped:irate5m) without (host, port, uplink, uplink_port)
   - record: infiniband:switch_port_qp1_dropped:switch_rate5m
     expr: sum(infiniband:switch_port_qp1_dropped:irate5m) without (host, port, uplink, uplink_port)
+- name: infiniband-port-state
+  rules:
+  - record: infiniband:switch_port_ever_connected
+    expr: max_over_time(infiniband_switch_port_state[30d]) == 1
+  - alert: InfinibandSwitchPortDown
+    expr: infiniband_switch_port_state == 0 and infiniband:switch_port_ever_connected
+    for: 5m
+    labels:
+      severity: warning
+      alertgroup: infiniband
+    annotations:
+      title: InfiniBand switch {{ $labels.switch }} port {{ $labels.port }} is down
+      description: Switch {{ $labels.switch }} ({{ $labels.guid }}) port {{ $labels.port }} link is down
 - name: infiniband
   rules:
   - alert: InfinibandCollectError


### PR DESCRIPTION
## Problem

When a switch port link goes down, `ibnetdiscover` reports it with `???`. The exporter skips these lines, so all metrics for that port vanish.
In Prometheus the time series goes stale — there is no `0` to alert on, only
absence, requiring fragile workarounds (`absent()`, `unless`, `last_over_time`).

## Solution

New flag `--collector.switch.port-state` (default `false`) adds a gauge:

    infiniband_switch_port_state{guid, switch, port}  1 = up, 0 = down

When enabled, `???` lines from `ibnetdiscover` are parsed instead of discarded.
Connected ports emit `1`, disconnected ports emit `0` — persistently, every
scrape. Alerting becomes `infiniband_switch_port_state == 0`.

When the flag is off, behavior remains unchanged and `???` lines are omitted.

## Backward compatibility

Flag defaults to `false`. No change in behavior, output, or dependencies for
existing users.